### PR TITLE
Need to make filter sendable across awaits

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -4,7 +4,7 @@
 ///
 
 /// The `Filter` trait is implemented by all the filters.
-pub trait Filter {
+pub trait Filter: Send {
     fn filter(&self) -> String;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &(impl Filter+?Sized),
         attributes: &Vec<&str>,
     ) -> Result<SearchEntry, Error> {
         let search = self
@@ -310,7 +310,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &impl Filter,
         attributes: &Vec<&str>,
     ) -> Result<T, Error> {
         let search_entry = self.search_innter(base, scope, filter, attributes).await?;


### PR DESCRIPTION
When runnig a seach query in across awaits (like in a request from axum) the Filter trait need to be sendable if one wants to make dynamic search queries.
Since the ?Sized super trait can't be set on this kind of trait it needs to be in the function signature, which leads it to be set do impl instead of dyn  (can't add supertraits to dyn Filter, only to impl Filter)