### PR TITLE
Using impl Filter instead of dyn Filter, to be able to send across th…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &impl Filter,
         attributes: &Vec<&str>,
     ) -> Result<T, Error> {
         let search_entry = self.search_innter(base, scope, filter, attributes).await?;
@@ -377,7 +377,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &(impl Filter + ?Sized),
         limit: i32,
         attributes: &Vec<&str>,
     ) -> Result<Vec<SearchEntry>, Error> {
@@ -472,7 +472,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &impl Filter,
         limit: i32,
         attributes: &Vec<&str>,
     ) -> Result<Vec<T>, Error> {
@@ -544,7 +544,7 @@ impl LdapClient {
         &mut self,
         base: &str,
         scope: Scope,
-        filter: &dyn Filter,
+        filter: &impl Filter,
         limit: i32,
         attributes: &Vec<&str>,
     ) -> Result<Vec<T>, Error> {


### PR DESCRIPTION
This is just using the impl Filter in order to facilitate that it will be possible when runnig a seach query in across awaits (like in a request from axum) the Filter trait need to be sendable if one wants to make dynamic search queries.
Since the ?Sized super trait can't be set on this kind of trait it needs to be in the function signature, which leads it to be set do impl instead of dyn (can't add supertraits to dyn Filter, only to impl Filter)


