### PR TITLE
Fix ldap3 feature usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.75"
 deadpool = "0.10.0"
-ldap3 = "0.11.3"
+ldap3 = { version = "0.11.3", default-features = false }
 log = "0.4.20"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"


### PR DESCRIPTION
This PR disables the default features for the ldap3 crate so that feature flag delegation works properly. In particular this enables the use of the `"tls-rustls"` flag which led to compilation errors before.