### PR TITLE
Added thiserror to Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 
@@ -18,8 +18,9 @@ deadpool = "0.10.0"
 futures = "0.3.31"
 ldap3 = { version = "0.11.5", default-features = false }
 log = "0.4.22"
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
+thiserror = "2.0.2"
 
 [features]
 default = ["ldap3/default"]


### PR DESCRIPTION
This pull request includes several updates to the `simple-ldap` project, including version upgrades, dependency additions, and error handling improvements. The most important changes are as follows:

### Version and Dependency Updates:

* Updated the version of the `simple-ldap` crate from `2.0.0` to `2.1.0` in `Cargo.toml`.
* Upgraded `serde` to version `1.0.214` and `serde_json` to version `1.0.132` in `Cargo.toml`. Added `thiserror` version `2.0.2` as a new dependency.

### Codebase Improvements:

* Imported the `thiserror::Error` trait in `src/lib.rs`.
* Enhanced the `Error` enum in `src/lib.rs` to derive the `Error` trait from `thiserror` and added error messages for each variant.

### Testing Enhancements:

* Modified test assertions in `src/lib.rs` to handle results more robustly by using `_` to ignore unused results [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1792-R1812) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1843-R1855) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1885-R1897).