### PR TITLE
Refactor deserialization of SearchEntry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 
 
@@ -19,6 +19,7 @@ futures = "0.3.31"
 ldap3 = { version = "0.11.5", default-features = false }
 log = "0.4.22"
 serde = { version = "1.0.214", features = ["derive"] }
+serde-value = "0.7.0"
 serde_json = "1.0.132"
 thiserror = "2.0.2"
 


### PR DESCRIPTION
This pull request includes several changes to the `simple-ldap` project, primarily focusing on updating dependencies and refactoring the `LdapClient` implementation to simplify JSON handling and mapping of search results to structs.

Dependency Updates:

* Updated the `version` in `Cargo.toml` from `2.1.0` to `2.1.1`.
* Added `serde-value = "0.7.0"` to the dependencies in `Cargo.toml`.

Refactoring JSON Handling:

* Removed the `create_json_signle_value`, `create_json_multi_value`, and `map_to_struct` methods from `LdapClient` and replaced them with `to_signle_value` and `to_multi_value` functions for converting search results directly to structs using `serde_value`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L280-R281) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L337-R336) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1169-R1230)
* Updated the `to_record` and `to_multi_valued_record_` methods in the `Record` struct to use the new `to_signle_value` and `to_multi_value` functions.

Test Adjustments:

* Modified the test cases to use the new `to_signle_value` and `to_multi_value` functions instead of the removed JSON creation and mapping methods. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L1509-R1510) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1522-R1535) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1548-R1549)