### PR TITLE
Feature prune and minor touch ups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         image: openidentityplatform/opendj
         ports:
           - 1389:1389
-        options: > 
+        options: >
           --env ROOT_USER_DN="cn=manager"
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,22 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      # Check that there are no SemVer violations before releasing.
+      # https://github.com/obi1kenobi/cargo-semver-checks
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+          features: pool
+
+      # Another check with the mutually exclusive tls-rustls feature enabled.
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: only-explicit-features
+          features: tls-rustls,pool
+
+
       - name: Deploy to crates.io
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2021"
 
 
@@ -33,9 +33,7 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.12.1", features = ["v4"] }
 
 [features]
-default = ["tls"]
-tls = ["ldap3/tls"]
+default = ["tls-native"]
 tls-native = ["ldap3/tls-native"]
 tls-rustls = ["ldap3/tls-rustls"]
-gssapi = ["ldap3/gssapi"]
 pool = ["dep:deadpool"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 
 [dependencies]
 deadpool = { version = "0.12.2", optional = true }
+derive_more = { version = "2.0.1", features = ["debug"] }
 futures = "0.3.31"
 ldap3 = { version = "0.11.5", default-features = false }
 serde = { version = "1.0.214", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A ldap client library that wraps [ldap3](https://github.com/inejge/ldap3) to mak
 [![Crates.io](https://img.shields.io/crates/v/simple-ldap)](https://crates.io/crates/simple-ldap)
 [![Documentation](https://docs.rs/simple-ldap/badge.svg)](https://docs.rs/simple-ldap)
 
+
 ## Usage
 
 Adding `simple_ldap` as a dependency to your project:
@@ -20,9 +21,6 @@ Other useful pieces you'll likely need:
 cargo add url serde --features serde/derive
 ```
 
-## ⚠️ Important Note
-
-**By default, this library enables the `tls` feature, which is an alias for `tls-native`. If you want to use `tls-rustls`, you have to disable the default feature by using `default-features = false` in your `Cargo.toml` file, as it conflicts with `tls-native`. Then, enable the feature you want to use.**
 
 ### Example
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,7 +1,7 @@
-/// # Filter
-///
-/// This module contains the implementation of the LDAP filter.
-///
+//! # Filter
+//!
+//! This module contains the implementation of the LDAP filter.
+//!
 
 /// The `Filter` trait is implemented by all the filters.
 pub trait Filter: Send {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,23 +100,28 @@ pub extern crate ldap3;
 const LDAP_ENTRY_DN: &str = "entryDN";
 const NO_SUCH_RECORD: u32 = 32;
 
+
 /// Configuration and authentication for LDAP connection
-#[derive(Clone)]
+#[derive(derive_more::Debug, Clone)]
 pub struct LdapConfig {
     pub ldap_url: Url,
     /// DistinguishedName, aka the "username" to use for the connection.
     pub bind_dn: String,
+    #[debug(skip)] // We don't want to print passwords.
     pub bind_password: String,
     pub dn_attribute: Option<String>,
     /// Low level configuration for the connection.
     /// You can probably skip it.
+    #[debug(skip)] // Debug omitted, because it just doesn't implement it.
     pub connection_settings: Option<LdapConnSettings>,
 }
+
 
 ///
 /// High-level LDAP client wrapper ontop of ldap3 crate. This wrapper provides a high-level interface to perform LDAP operations
 /// including authentication, search, update, delete
 ///
+#[derive(Debug, Clone)]
 pub struct LdapClient {
     /// The internal connection handle.
     ldap: Ldap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@
 //!
 //! ## Usage
 //!
-//! Add this to your `Cargo.toml`:
-//! ```toml
-//! [dependencies]
-//! simple-ldap = "3.0.0"
+//! Adding `simple_ldap` as a dependency to your project:
 //!
+//! ```commandline
+//! cargo add simple-ldap
 //! ```
+//!
+//! Most functionalities are defined on the `LdapClient` type. Have a look at the docs.
+//!
 //!
 //! ### Example
 //!
@@ -67,11 +69,9 @@
 //!
 //! ## Compile time features
 //!
-//! * `tls` - (Enabled by default) Enables TLS support (delegates to `ldap3`'s `tls` feature)
-//! * `tls-rustls` - Enables TLS support using `rustls` (delegates to `ldap3`'s `tls-rustls` feature)
-//! * `gsasl` - Enables SASL support (delegates to `ldap3`'s `gsasl` feature)
+//! * `tls-native` - (Enabled by default) Enables TLS support using the systems native implementation.
+//! * `tls-rustls` - Enables TLS support using `rustls`. **Conflicts with `tls-native` so you need to disable default features to use this.
 //! * `pool` - Enable connection pooling
-//!
 //!
 
 use std::{


### PR DESCRIPTION
Hey @keaz!

A small PR:

# Features

This PR mainly prunes redundant crate features. Namely `tls` which was just a confusing alias, and `gssapi` which wasn't usable anyway as we didn't expose the `sasl_gssapi_bind()` function.

 
# LdapClient

I forgot to make it `Clone` last time, so now it is. Also made some things `Debug`.


# Cargo-semver-checks

I added cargo-semver-checks to the release pipeline. This effectively prevents accidental SemVer violations.

However I haven't been able to test the pipeline, so there might be some rough edges there. You can contact me about issues.


# Issues

Fixes: #20 