### PR TITLE
Serialize binary attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - '*'
-      - '!main'
 
 jobs:
   build:
@@ -15,7 +14,7 @@ jobs:
         image: openidentityplatform/opendj
         ports:
           - 1389:1389
-        options: > 
+        options: >
           --env ROOT_USER_DN="cn=manager"
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,12 @@ name: Publish to crates.io
 
 on:
   push:
-    branches:
-      - 'main'
+    tags:
+      # Only on SemVer tags like "7.3.0".
+      # Push a new tag to make a new release.
+      # It should match the version in Cargo.toml
+      # (Perhaps we could add a check for this?)
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 
 
@@ -24,14 +24,14 @@ tracing = "0.1.41"
 url = "2.5.4"
 
 [dev-dependencies]
-# This little hack is neede0.9.0 enabling optional features during testing.
+# This little hack is needed for enabling optional features during testing.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
 anyhow = "1.0.95"
 rand = "0.9.0"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
-uuid = { version = "1.12.1", features = ["v4"] }
+uuid = { version = "1.12.1", features = ["v4", "serde"] }
 
 [features]
 default = ["tls-native"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //!     dn: String,
 //!     cn: String,
 //!     // LDAP and Rust naming conventions differ.
-//!     // You can make up for the difference by using `serde`'s renaming annotations.
+//!     // You can make up for the difference by using serde's renaming annotations.
 //!     #[serde(rename = "mayNotExist")]
 //!     may_not_exist: Option<String>,
 //!     multivalued_attribute: Vec<String>

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -96,7 +96,7 @@ pub async fn test_search_record<Client: DerefMut<Target = LdapClient>>(mut clien
             &vec!["cn", "sn", "uid"],
         )
         .await;
-    assert!(user.is_ok());
+
     let user = user.unwrap();
     assert_eq!(user.cn, "Sam");
     assert_eq!(user.sn, "Smith");


### PR DESCRIPTION
# Summary

Makes binary attributes available for deserialization. You need to use compatible types, i.e. types that can deserialize from a sequence of bytes.


## DN

Since the server always returns DN, I added it to the intermediary serde representation as well. It can always be deserialized.


## Uploading binary

I didn't do anything for this. I don't yet know how it's supposed to work. It's possible that you anyway need to upload it as some sort of string representation. We'll cross that bridge when it becomes relevant.


## CI

I changed the `publish` workflow to run only on SemVer tags. So you'll need to add a `5.1.0` tag to the repository to make a release. I hope it works.


## Tests

Binary deserialization is only tested offline. It would be nice to do it with the test server as well, but I just have no idea how to add a binary attribute to `data/data.ldif`. Do let me know if you know how.


# Future plans

I don't think the single-value / multi-value distinction is sound in this crate. Currently you have to make the call *for the whole type* at once, whereas more realistically some fields will be multivalued and others not.

I think we should serialize everything as multivalued (as returned by `ldap3`), and then document how to coerce the Vecs to single values (or Options) with serde.

Anyway I didn't make any changes to it now. I'll open up another issue for it.



Fixes: #24 