### PR TITLE
Refactor search streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "6.0.1"
+version = "7.0.0"
 edition = "2021"
 
 
@@ -33,6 +33,7 @@ tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
 uuid = { version = "1.16.0", features = ["v4", "serde"] }
 serde_with = "3.12.0"
+tracing-subscriber = "0.3.19"
 
 [features]
 default = ["tls-native"]

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -66,9 +66,15 @@ async fn test_streaming_search() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_streaming_search_with() -> anyhow::Result<()> {
+async fn test_streaming_search_paged() -> anyhow::Result<()> {
     let client = get_test_client().await?;
-    client_test_cases::test_streaming_search_with(Box::new(client)).await
+    client_test_cases::test_streaming_search_paged(Box::new(client)).await
+}
+
+#[tokio::test]
+async fn test_search_stream_drop() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_search_stream_drop(Box::new(client)).await
 }
 
 #[tokio::test]

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -83,8 +83,13 @@ async fn test_streaming_search() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_streaming_search_with() -> anyhow::Result<()> {
-    dispatch_parallel_test(client_test_cases::test_streaming_search_with).await
+async fn test_streaming_search_paged() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_streaming_search_paged).await
+}
+
+#[tokio::test]
+async fn test_search_stream_drop() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_search_stream_drop).await
 }
 
 #[tokio::test]


### PR DESCRIPTION
Changed to stream implementation to one which leaves less space for tricky errors.

Streams are now returned as trait objects.

Cleanup happens automatically, but unfortunately synchronously. Let's hope `AsyncDrop` gets stabilized one day.
In practice this is not an issue, as there's not much to do if the stream is run into completion, which should be the common case.

Not having to worry about cleanup allows you to use consuming stream combinators like `try_for_each()`. Previously it would have been practically impossible to call `cleanup()` after this.

The returned streams are not `Unpin`, meaning that you might have to pin them with `Box::pin()` before using some operations, notably `next()`. Rust Stream users should be familiar with this.

As this was anyway a breaking change, I took the opportunity to rename `streaming_search_with()` to `streaming_search_paged()`, which is more descriptive.



fixes: #27 