### PR TITLE
Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "7.0.0"
-edition = "2021"
+version = "7.0.1"
+edition = "2024"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Bump rust edition to 2024.

No code changes were needed according to `cargo`. Tests still pass.

This is just for making future development nicer.

The only possible changes are differences implicit drop orders, which I don't think this crate depends on in any way.