### PR TITLE
Search attribute arg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "7.1.0"
+version = "8.0.0"
 edition = "2024"
 
 

--- a/examples/return_stream.rs
+++ b/examples/return_stream.rs
@@ -1,0 +1,63 @@
+//! Just some test code I used to checkt that it compiles.
+//! Should be removed before release.
+
+use simple_ldap::{
+    filter::EqFilter,
+    ldap3::Scope,
+    Error, LdapClient, LdapConfig, Record
+};
+use url::Url;
+use serde::Deserialize;
+use futures::{Stream, StreamExt};
+#[derive(Deserialize, Debug)]
+struct User {
+    uid: String,
+    cn: String,
+    sn: String,
+}
+
+#[tokio::main]
+async fn main(){
+    let ldap_config = LdapConfig {
+        bind_dn: String::from("cn=manager"),
+        bind_password: String::from("password"),
+        ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
+        dn_attribute: None,
+        connection_settings: None
+    };
+    let mut client = LdapClient::new(ldap_config).await.unwrap();
+
+    let stream = return_stream(&mut client).await;
+
+    // The returned stream is not Unpin, so you may need to pin it to use certain operations,
+    // such as next() below.
+    let mut pinned_steam = Box::pin(stream);
+    while let Some(result) = pinned_steam.next().await {
+        match result {
+            Ok(element) => {
+                let user: User = element.to_record().unwrap();
+                println!("User: {user:?}");
+            }
+            Err(err) => {
+                println!("Error: {err:?}");
+            }
+        }
+    }
+}
+
+
+/// With the arguments being `AsRef` it's easy to write functions like this,
+/// where the arguments are neatly packaged in the return object.
+async fn return_stream<'a>(client: &'a mut LdapClient) -> impl Stream<Item = Result<Record, Error>> + use<'a>
+{
+  let local_base = String::from("dog");
+  let name_filter = EqFilter::from(String::from("cn"), String::from("Sam"));
+  let local_attrs = vec!["cn"];
+
+  client.streaming_search(
+      local_base,
+      Scope::OneLevel,
+      name_filter,
+      local_attrs
+  ).await.unwrap()
+}

--- a/examples/return_stream.rs
+++ b/examples/return_stream.rs
@@ -55,9 +55,9 @@ async fn return_stream<'a>(client: &'a mut LdapClient) -> impl Stream<Item = Res
   let local_attrs = vec!["cn"];
 
   client.streaming_search(
-      local_base,
+      &local_base,
       Scope::OneLevel,
-      name_filter,
+      &name_filter,
       local_attrs
   ).await.unwrap()
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -63,6 +63,13 @@ impl Filter for AndFilter {
     }
 }
 
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<AndFilter> for AndFilter {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// The `OrFilter` struct represents an OR filter.
 #[derive(Default)]
 pub struct OrFilter {
@@ -118,6 +125,13 @@ impl Filter for OrFilter {
     }
 }
 
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<OrFilter> for OrFilter {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// The `EqFilter` struct represents an equality filter.
 pub struct EqFilter {
     attribute: String,
@@ -149,6 +163,13 @@ impl Filter for EqFilter {
     }
 }
 
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<EqFilter> for EqFilter {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// The `NotFilter` struct represents a NOT filter.
 /// This filter represents the negation of another filter. This is equal to LDAP `!` operator.
 pub struct NotFilter {
@@ -176,6 +197,13 @@ impl NotFilter {
 impl Filter for NotFilter {
     fn filter(&self) -> String {
         format!("(!{})", self.filter.filter())
+    }
+}
+
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<NotFilter> for NotFilter {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 
@@ -228,6 +256,13 @@ impl Filter for LikeFilter {
     }
 }
 
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<LikeFilter> for LikeFilter {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// The `ContainsFilter` struct represents a CONTAINS filter.
 /// This generates a ldap filter that checks if the value is contained in the attribute.
 pub struct ContainsFilter {
@@ -257,6 +292,13 @@ impl ContainsFilter {
 impl Filter for ContainsFilter {
     fn filter(&self) -> String {
         format!("({}=*{}*)", self.attribute, self.value)
+    }
+}
+
+// All filters should have a reflexive `AsRef` implementation.
+impl AsRef<ContainsFilter> for ContainsFilter {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -63,13 +63,6 @@ impl Filter for AndFilter {
     }
 }
 
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<AndFilter> for AndFilter {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
 /// The `OrFilter` struct represents an OR filter.
 #[derive(Default)]
 pub struct OrFilter {
@@ -125,13 +118,6 @@ impl Filter for OrFilter {
     }
 }
 
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<OrFilter> for OrFilter {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
 /// The `EqFilter` struct represents an equality filter.
 pub struct EqFilter {
     attribute: String,
@@ -163,13 +149,6 @@ impl Filter for EqFilter {
     }
 }
 
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<EqFilter> for EqFilter {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
 /// The `NotFilter` struct represents a NOT filter.
 /// This filter represents the negation of another filter. This is equal to LDAP `!` operator.
 pub struct NotFilter {
@@ -197,13 +176,6 @@ impl NotFilter {
 impl Filter for NotFilter {
     fn filter(&self) -> String {
         format!("(!{})", self.filter.filter())
-    }
-}
-
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<NotFilter> for NotFilter {
-    fn as_ref(&self) -> &Self {
-        self
     }
 }
 
@@ -256,13 +228,6 @@ impl Filter for LikeFilter {
     }
 }
 
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<LikeFilter> for LikeFilter {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
 /// The `ContainsFilter` struct represents a CONTAINS filter.
 /// This generates a ldap filter that checks if the value is contained in the attribute.
 pub struct ContainsFilter {
@@ -292,13 +257,6 @@ impl ContainsFilter {
 impl Filter for ContainsFilter {
     fn filter(&self) -> String {
         format!("({}=*{}*)", self.attribute, self.value)
-    }
-}
-
-// All filters should have a reflexive `AsRef` implementation.
-impl AsRef<ContainsFilter> for ContainsFilter {
-    fn as_ref(&self) -> &Self {
-        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,7 @@ impl LdapClient {
     {
         let search_stream = self
             .ldap
-            .streaming_search(base.as_ref(), scope, filter.filter().as_str(), attributes)
+            .streaming_search(base, scope, filter.filter().as_str(), attributes)
             .await
             .map_err(|ldap_error| {
                 Error::Query(


### PR DESCRIPTION
This is WIP showcasing the API proposal for reference arguments. 
I only did `streaming_search()` so far just to see how it would play out. Looking quite good so far.


# Key changes to search arguments

- Only the `attributes` argument actually needs the lifetime bound. It can be dropped from base and filter.
- Attributes arg changed to `AsRef`.

Together these allow you to write functions that return stream objects, without worrying too much about argument lifetimes. Have a look at the included example file. This shouldn't break much of anything, as usage becomes *less restrictive*.


What do you think @keaz? Should I write the rest along the same lines?


# Issue refs

fixes: #31 