### PR TITLE
Add integration tests for authentication and multi-valued search

### DIFF
--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -42,6 +42,12 @@ async fn test_search_multiple_record() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_search_multi_valued() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_search_multi_valued(Box::new(client)).await
+}
+
+#[tokio::test]
 async fn test_update_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_update_record(Box::new(client)).await
@@ -123,4 +129,16 @@ async fn test_remove_users_from_group() -> anyhow::Result<()> {
 async fn test_associated_groups() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_associated_groups(Box::new(client)).await
+}
+
+#[tokio::test]
+async fn test_authenticate_success() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_authenticate_success(Box::new(client)).await
+}
+
+#[tokio::test]
+async fn test_authenticate_wrong_password() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_authenticate_wrong_password(Box::new(client)).await
 }

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -63,6 +63,11 @@ async fn test_search_multiple_record() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_search_multi_valued() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_search_multi_valued).await
+}
+
+#[tokio::test]
 async fn test_update_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_update_record).await
 }
@@ -130,4 +135,14 @@ async fn test_remove_users_from_group() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_associated_groups() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_associated_groups).await
+}
+
+#[tokio::test]
+async fn test_authenticate_success() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_authenticate_success).await
+}
+
+#[tokio::test]
+async fn test_authenticate_wrong_password() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_authenticate_wrong_password).await
 }


### PR DESCRIPTION
## Summary
- add reusable multi-valued search and authentication test cases to the shared integration harness
- run the new scenarios through both pooled and non-pooled client wrappers so the suites stay in sync

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68ca67abc140832d9df28e2082bda4f7