### PR TITLE
The stream returning is valid only for lifetime 'a, which matches the…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,7 +656,7 @@ impl LdapClient {
         scope: Scope,
         filter: &F,
         attributes: A,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
+    ) -> Result<impl Stream<Item = Result<Record, Error>> + 'a + use<'a, F, A, S>, Error>
     where
         F: Filter,
         A: AsRef<[S]> + Send + Sync + 'a,
@@ -1789,7 +1789,7 @@ where
 /// A helper to create native rust streams out of `ldap3::SearchStream`s.
 fn to_native_stream<'a, S, A>(
     ldap3_stream: SearchStream<'a, S, A>,
-) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, S, A>, Error>
+) -> Result<impl Stream<Item = Result<Record, Error>> + 'a + use<'a, S, A>, Error>
 where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,


### PR DESCRIPTION
The stream returning is valid only for lifetime 'a, which matches the lifetime of the borrowed client and SearchStram<'a,S,A>


the compiler inferred that the returned impl Stream<...> needed to be 'static, but your generic parameters S and A were only constrained to live at least as long as 'a (the lifetime tied to &'a mut self), not necessarily for 'static.

this PR;   “the stream I’m returning is valid only for lifetime 'a,” which matches the lifetime of the borrowed client and SearchStream<'a, S, A> you’re wrapping.

You do not need to force S and A to be 'static; they can still carry non-'static data as long as they live at least 'a.
