### PR TITLE
Release v8.0.2: dependency updates + Rust 1.91+ build fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "8.0.0"
+version = "8.0.2"
 edition = "2024"
 
 
@@ -14,30 +14,30 @@ edition = "2024"
 
 [dependencies]
 chumsky = "0.10.1"
-deadpool = { version = "0.12.2", optional = true }
-derive_more = { version = "2.0.1", features = ["debug", "display"] }
-futures = "0.3.31"
+deadpool = { version = "0.12.3", optional = true }
+derive_more = { version = "2.1.1", features = ["debug", "display"] }
+futures = "0.3.32"
 itertools = "0.14.0"
 ldap3 = { version = "0.11.5", default-features = false }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde-value = "0.7.0"
-serde_with = "3.12.0"
-thiserror = "2.0.12"
-tracing = "0.1.41"
-url = "2.5.4"
+serde_with = "3.16.1"
+thiserror = "2.0.18"
+tracing = "0.1.44"
+url = "2.5.8"
 
 [dev-dependencies]
 # This little hack is needed for enabling optional features during testing.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
-anyhow = "1.0.98"
-rand = "0.9.0"
-tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
+anyhow = "1.0.102"
+rand = "0.9.2"
+tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
-uuid = { version = "1.16.0", features = ["v4", "serde"] }
-serde_with = "3.12.0"
-tracing-subscriber = "0.3.19"
-serde_json = "1.0.142"
+uuid = { version = "1.21.0", features = ["v4", "serde"] }
+serde_with = "3.16.1"
+tracing-subscriber = "0.3.22"
+serde_json = "1.0.149"
 
 [features]
 default = ["tls-native"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt, iter,
 };
+use std::pin::Pin;
 
 use filter::{AndFilter, EqFilter, Filter, OrFilter};
 use futures::{Stream, StreamExt, executor::block_on, stream};
@@ -656,7 +657,7 @@ impl LdapClient {
         scope: Scope,
         filter: &F,
         attributes: A,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
     where
         F: Filter,
         A: AsRef<[S]> + Send + Sync + 'a,
@@ -778,7 +779,7 @@ impl LdapClient {
         filter: &F,
         attributes: A,
         page_size: i32,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
     where
         F: Filter,
         // PagedResults requires Clone and Debug too.
@@ -1789,7 +1790,7 @@ where
 /// A helper to create native rust streams out of `ldap3::SearchStream`s.
 fn to_native_stream<'a, S, A>(
     ldap3_stream: SearchStream<'a, S, A>,
-) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, S, A>, Error>
+) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
 where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,
@@ -1818,7 +1819,7 @@ where
         }
     });
 
-    Ok(stream)
+    Ok(Box::pin(stream))
 }
 
 /// The Record struct is used to map the search result to a struct.


### PR DESCRIPTION
## **User description**
## Summary
- bump crate version to `8.0.2`
- update direct dependencies in `Cargo.toml` to current compatible versions
- fix Rust 1.91+ lifetime build regression in streaming search by returning boxed streams (without adding `'static` bounds)

## Validation
- `cargo test` (unit, integration with Docker OpenDJ, pool tests, and doctests)

Closes #38


___

## **CodeAnt-AI Description**
**Release v8.0.2: dependency updates and Rust 1.91+ build fix**

### What Changed
- Builds now succeed on Rust 1.91+ by returning boxed, pinned streams for streaming search APIs, avoiding previous lifetime errors with pooled clients.
- Updated multiple dependencies and crate version to 8.0.2 so the library uses newer patch releases for transitive crates.
- Streaming search behavior for pooled clients no longer requires artificial external lifetimes, making pooled usage compile cleanly.

### Impact
`✅ Builds on Rust 1.91+`
`✅ Easier use with connection pools (no lifetime compile errors)`
`✅ Uses newer dependency releases`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
