### PR TITLE
Fix bug issues: preserve members and decode escaped DNs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "8.0.2"
+version = "8.0.3"
 edition = "2024"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "8.0.0"
+version = "8.0.2"
 edition = "2024"
 
 
@@ -14,30 +14,30 @@ edition = "2024"
 
 [dependencies]
 chumsky = "0.10.1"
-deadpool = { version = "0.12.2", optional = true }
-derive_more = { version = "2.0.1", features = ["debug", "display"] }
-futures = "0.3.31"
+deadpool = { version = "0.12.3", optional = true }
+derive_more = { version = "2.1.1", features = ["debug", "display"] }
+futures = "0.3.32"
 itertools = "0.14.0"
 ldap3 = { version = "0.11.5", default-features = false }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde-value = "0.7.0"
-serde_with = "3.12.0"
-thiserror = "2.0.12"
-tracing = "0.1.41"
-url = "2.5.4"
+serde_with = "3.16.1"
+thiserror = "2.0.18"
+tracing = "0.1.44"
+url = "2.5.8"
 
 [dev-dependencies]
 # This little hack is needed for enabling optional features during testing.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
-anyhow = "1.0.98"
-rand = "0.9.0"
-tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
+anyhow = "1.0.102"
+rand = "0.9.2"
+tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
-uuid = { version = "1.16.0", features = ["v4", "serde"] }
-serde_with = "3.12.0"
-tracing-subscriber = "0.3.19"
-serde_json = "1.0.142"
+uuid = { version = "1.21.0", features = ["v4", "serde"] }
+serde_with = "3.16.1"
+tracing-subscriber = "0.3.22"
+serde_json = "1.0.149"
 
 [features]
 default = ["tls-native"]

--- a/data/data.ldif
+++ b/data/data.ldif
@@ -81,3 +81,19 @@ objectClass: top
 objectClass: groupOfNames
 cn: grp2
 member: uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com
+
+dn: uid=user\,one\+two\=three,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+sn: Escape
+cn: Escaped Member
+ou: people
+uid: user,one+two=three
+
+dn: cn=grp_escaped,ou=group,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: grp_escaped
+member: uid=user\,one\+two\=three,ou=people,dc=example,dc=com

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt, iter,
 };
+use std::pin::Pin;
 
 use filter::{AndFilter, EqFilter, Filter, OrFilter};
 use futures::{Stream, StreamExt, executor::block_on, stream};
@@ -656,7 +657,7 @@ impl LdapClient {
         scope: Scope,
         filter: &F,
         attributes: A,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
     where
         F: Filter,
         A: AsRef<[S]> + Send + Sync + 'a,
@@ -778,7 +779,7 @@ impl LdapClient {
         filter: &F,
         attributes: A,
         page_size: i32,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
     where
         F: Filter,
         // PagedResults requires Clone and Debug too.
@@ -1789,7 +1790,7 @@ where
 /// A helper to create native rust streams out of `ldap3::SearchStream`s.
 fn to_native_stream<'a, S, A>(
     ldap3_stream: SearchStream<'a, S, A>,
-) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, S, A>, Error>
+) -> Result<Pin<Box<dyn Stream<Item = Result<Record, Error>> + 'a>>, Error>
 where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,
@@ -1818,7 +1819,7 @@ where
         }
     });
 
-    Ok(stream)
+    Ok(Box::pin(stream))
 }
 
 /// The Record struct is used to map the search result to a struct.

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -108,9 +108,21 @@ async fn test_add_users_to_group() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_add_users_to_group_preserves_existing_members() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_add_users_to_group_preserves_existing_members(Box::new(client)).await
+}
+
+#[tokio::test]
 async fn test_get_members() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_get_members(Box::new(client)).await
+}
+
+#[tokio::test]
+async fn test_get_members_escaped_dn() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::test_get_members_escaped_dn(Box::new(client)).await
 }
 
 #[tokio::test]

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -118,8 +118,18 @@ async fn test_add_users_to_group() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_add_users_to_group_preserves_existing_members() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_add_users_to_group_preserves_existing_members).await
+}
+
+#[tokio::test]
 async fn test_get_members() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_get_members).await
+}
+
+#[tokio::test]
+async fn test_get_members_escaped_dn() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::test_get_members_escaped_dn).await
 }
 
 #[tokio::test]


### PR DESCRIPTION
## **User description**
This PR addresses remaining bug-tagged LDAP gaps:

- group membership add: switch to Mod::Add so existing members are preserved
- get_members parsing: use escaped DN-aware parsing for member extraction
- binary multi-valued regular mapper: map bin_attrs with multiple values to Vec<Vec<u8>>/Vec<Uuid>
- added regression tests:
  - preserves existing members when adding users to group
  - parses escaped DN RDNs in group members
  - verifies multi-valued binary mapping to regular mapper

Also updates data/data.ldif with escaped DN fixture and bumps crate version to 8.0.3.

Validation:
- 
- import data fixture from data/data.ldif into OpenDJ
- 
running 32 tests
test filter::tests::test_contains_filter ... ok
test filter::tests::test_and_filter ... ok
test filter::tests::test_eq_filter ... ok
test filter::tests::test_not_eq_filter ... ok
test filter::tests::test_or_filter ... ok
test filter::tests::test_pre_like_filter ... ok
test filter::tests::test_post_like_filter ... ok
test simple_dn::tests::get ... ok
test simple_dn::tests::dispaly_simple_dn ... ok
test simple_dn::tests::get_parent ... ok
test simple_dn::tests::get_starting_from ... ok
test simple_dn::tests::get_type ... ok
test simple_dn::tests::get_type_starting_from ... ok
test simple_dn::tests::deserialize ... ok
test simple_dn::tests::parse_complex_dn ... ok
test simple_dn::tests::parse_dn_escapes ... ok
test simple_dn::tests::parse_simple_rdn_fail ... ok
test simple_dn::tests::parse_simple_rdn_ok ... ok
test simple_dn::tests::parse_sipmle_dn_ok ... ok
test simple_dn::tests::partial_compare ... ok
test simple_dn::tests::serialize ... ok
test simple_dn::tests::test_common_ancestor ... ok
test tests::binary_multi_to_value_test ... ok
test tests::binary_multi_to_uuid_value_test ... ok
test tests::binary_single_to_value_test ... ok
test tests::create_multi_value_test ... ok
test tests::create_single_value_test ... ok
test tests::create_to_value_string_test ... ok
test tests::deserialize_binary_multi_value_test ... ok
test tests::deserialize_binary_single_value_test ... ok
test tests::member_dn_to_filter_components_escaped_rdn_value ... ok
test tests::member_dn_to_filter_components_invalid_input_is_ignored ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 20 tests
test test_associated_groups ... ok
2026-02-23T00:26:58.539748Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"uid": ["user,one+two=three"], "sn": ["Escape"], "cn": ["Escaped Member"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.539800Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"uid": ["user,one+two=three"], "sn": ["Escape"], "cn": ["Escaped Member"]}, bin_attrs: {} }}: simple_ldap: close time.busy=37.3µs time.idle=20.0µs
2026-02-23T00:26:58.540005Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.540015Z TRACE cleanup: simple_ldap: close time.busy=3.08µs time.idle=8.67µs
test test_get_members_escaped_dn ... ok
2026-02-23T00:26:58.540162Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.540448Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"sn": ["Smith"], "cn": ["Sam"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.540484Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"sn": ["Smith"], "cn": ["Sam"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: close time.busy=23.2µs time.idle=13.4µs
test test_search_record ... ok
2026-02-23T00:26:58.540607Z DEBUG simple_ldap: Creating new connection
test test_search_multiple_record ... ok
2026-02-23T00:26:58.540887Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.541243Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.541264Z TRACE cleanup: simple_ldap: close time.busy=7.33µs time.idle=14.3µs
test test_no_record_delete ... ok
2026-02-23T00:26:58.541328Z DEBUG simple_ldap: Creating new connection
test test_search_stream_drop ... ok
2026-02-23T00:26:58.541380Z DEBUG simple_ldap: Creating new connection
test test_search_no_record ... ok
2026-02-23T00:26:58.542991Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.543034Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=31.6µs time.idle=12.9µs
2026-02-23T00:26:58.543052Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "sn": ["Gunn"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.543073Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "sn": ["Gunn"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=15.5µs time.idle=5.50µs
2026-02-23T00:26:58.543180Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.543190Z TRACE cleanup: simple_ldap: close time.busy=2.88µs time.idle=6.83µs
test test_streaming_search ... ok
2026-02-23T00:26:58.543956Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.544210Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.544231Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_create_record ... ok
2026-02-23T00:26:58.545021Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.545038Z TRACE cleanup: simple_ldap: close time.busy=4.08µs time.idle=13.6µs
test test_update_no_record ... ok
test test_streaming_search_no_records ... ok
test test_add_users_to_group ... ok
2026-02-23T00:26:58.545353Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_update_record ... ok
2026-02-23T00:26:58.546151Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_create_group ... ok
2026-02-23T00:26:58.546356Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.546628Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.546701Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.546750Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"]}, bin_attrs: {} }}: simple_ldap: close time.busy=38.0µs time.idle=11.2µs
2026-02-23T00:26:58.547045Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.547143Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"]}, bin_attrs: {} }}: simple_ldap: close time.busy=75.2µs time.idle=23.7µs
test test_remove_users_from_group ... ok
2026-02-23T00:26:58.548699Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"cn": ["Jhon_Update"], "sn": ["Eliet_Update"], "uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.548775Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"cn": ["Jhon_Update"], "sn": ["Eliet_Update"], "uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"]}, bin_attrs: {} }}: simple_ldap: close time.busy=55.2µs time.idle=22.2µs
2026-02-23T00:26:58.548894Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.548912Z TRACE cleanup: simple_ldap: close time.busy=6.42µs time.idle=12.7µs
test test_streaming_search_paged ... ok
2026-02-23T00:26:58.549129Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.549512Z DEBUG simple_ldap: Sucessfully deleted record result: "0b8bbb0b-6598-4509-a556-c14104a456d3"
test test_delete ... ok
2026-02-23T00:26:58.550011Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.550048Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: close time.busy=25.6µs time.idle=12.3µs
2026-02-23T00:26:58.550171Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"cn": ["David"], "sn": ["Hanks"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.550195Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"cn": ["David"], "sn": ["Hanks"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"]}, bin_attrs: {} }}: simple_ldap: close time.busy=16.2µs time.idle=7.67µs
2026-02-23T00:26:58.550206Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.550214Z TRACE cleanup: simple_ldap: close time.busy=2.54µs time.idle=5.33µs
test test_get_members ... ok
2026-02-23T00:26:58.551273Z DEBUG simple_ldap: Sucessfully updated dn result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.551901Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=128a0702-5301-4b54-a496-1f31d7a58c6b,ou=people,dc=example,dc=com", attrs: {"sn": ["Updated"], "uid": ["128a0702-5301-4b54-a496-1f31d7a58c6b"], "cn": ["I'm"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.551939Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=128a0702-5301-4b54-a496-1f31d7a58c6b,ou=people,dc=example,dc=com", attrs: {"sn": ["Updated"], "uid": ["128a0702-5301-4b54-a496-1f31d7a58c6b"], "cn": ["I'm"]}, bin_attrs: {} }}: simple_ldap: close time.busy=25.3µs time.idle=13.8µs
test test_update_uid_record ... ok
2026-02-23T00:26:58.552449Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.552494Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: close time.busy=34.4µs time.idle=12.0µs
2026-02-23T00:26:58.552549Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"cn": ["David"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "sn": ["Hanks"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.552577Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"cn": ["David"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "sn": ["Hanks"]}, bin_attrs: {} }}: simple_ldap: close time.busy=21.3µs time.idle=6.63µs
2026-02-23T00:26:58.552591Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.552599Z TRACE cleanup: simple_ldap: close time.busy=2.67µs time.idle=5.38µs
test test_add_users_to_group_preserves_existing_members ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 20 tests
test test_associated_groups ... ok
2026-02-23T00:26:58.566821Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.566840Z DEBUG simple_ldap: Creating new connection
test test_search_no_record ... ok
2026-02-23T00:26:58.568079Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.568090Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.568255Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.568275Z TRACE cleanup: simple_ldap: close time.busy=7.63µs time.idle=14.0µs
2026-02-23T00:26:58.568774Z  WARN ldap3::conn: unmatched id: 2
2026-02-23T00:26:58.569241Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.569288Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: close time.busy=35.5µs time.idle=12.2µs
2026-02-23T00:26:58.569333Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"sn": ["Escape"], "uid": ["user,one+two=three"], "cn": ["Escaped Member"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.569350Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"], "cn": ["Sam"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.569374Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"], "cn": ["Sam"]}, bin_attrs: {} }}: simple_ldap: close time.busy=17.7µs time.idle=7.25µs
2026-02-23T00:26:58.569414Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"sn": ["Escape"], "uid": ["user,one+two=three"], "cn": ["Escaped Member"]}, bin_attrs: {} }}: simple_ldap: close time.busy=57.2µs time.idle=26.9µs
2026-02-23T00:26:58.569444Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.569483Z TRACE cleanup: simple_ldap: close time.busy=24.7µs time.idle=14.8µs
test test_search_record ... ok
2026-02-23T00:26:58.569590Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.569599Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.569856Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"cn": ["Escaped Member"], "sn": ["Escape"], "uid": ["user,one+two=three"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.569886Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=user\\,one\\+two\\=three,ou=people,dc=example,dc=com", attrs: {"cn": ["Escaped Member"], "sn": ["Escape"], "uid": ["user,one+two=three"]}, bin_attrs: {} }}: simple_ldap: close time.busy=22.7µs time.idle=7.96µs
2026-02-23T00:26:58.569899Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.569906Z TRACE cleanup: simple_ldap: close time.busy=2.38µs time.idle=5.17µs
2026-02-23T00:26:58.569930Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_search_multiple_record ... ok
2026-02-23T00:26:58.570012Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.570030Z DEBUG simple_ldap: Creating new connection
test test_get_members_escaped_dn ... ok
2026-02-23T00:26:58.570106Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.570112Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.570359Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.570378Z TRACE cleanup: simple_ldap: close time.busy=7.71µs time.idle=11.3µs
test test_search_stream_drop ... ok
2026-02-23T00:26:58.570601Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.570612Z DEBUG simple_ldap: Creating new connection
test test_no_record_delete ... ok
2026-02-23T00:26:58.571353Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.572208Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.572219Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.572241Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.573083Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.573083Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.573090Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.573092Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.573163Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.573182Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.573296Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.573300Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.573870Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.574150Z DEBUG simple_ldap::pool: Creating new connection
2026-02-23T00:26:58.574156Z DEBUG simple_ldap: Creating new connection
2026-02-23T00:26:58.574825Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.574840Z TRACE cleanup: simple_ldap: close time.busy=3.96µs time.idle=12.3µs
2026-02-23T00:26:58.574856Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.574864Z TRACE cleanup: simple_ldap: close time.busy=1.92µs time.idle=6.75µs
test test_streaming_search_no_records ... ok
2026-02-23T00:26:58.576790Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.576906Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.577057Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"], "sn": ["Gunn"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.577104Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"], "sn": ["Gunn"]}, bin_attrs: {} }}: simple_ldap: close time.busy=35.7µs time.idle=11.3µs
2026-02-23T00:26:58.577229Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.577252Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=17.0µs time.idle=6.46µs
2026-02-23T00:26:58.577729Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.577812Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.577838Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"cn": ["James"], "sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"]}, bin_attrs: {} }}: simple_ldap: close time.busy=17.2µs time.idle=8.83µs
2026-02-23T00:26:58.577852Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
test test_create_record ... ok
2026-02-23T00:26:58.577870Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=13.8µs time.idle=4.67µs
2026-02-23T00:26:58.578339Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.578349Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.578359Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=14.8µs time.idle=5.54µs
2026-02-23T00:26:58.578375Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=42b05942-4f18-4279-827d-36534da1e437,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "uid": ["42b05942-4f18-4279-827d-36534da1e437"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=18.7µs time.idle=7.25µs
2026-02-23T00:26:58.578395Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "sn": ["Gunn"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.578419Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"], "sn": ["Gunn"], "cn": ["James"]}, bin_attrs: {} }}: simple_ldap: close time.busy=16.9µs time.idle=7.25µs
2026-02-23T00:26:58.578434Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.578444Z TRACE cleanup: simple_ldap: close time.busy=2.83µs time.idle=8.12µs
2026-02-23T00:26:58.578981Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "cn": ["James"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.579008Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=0xbaece8-f5f8-4e85-97d8-8bd614304bef,ou=people,dc=example,dc=com", attrs: {"sn": ["Gunn"], "cn": ["James"], "uid": ["0xbaece8-f5f8-4e85-97d8-8bd614304bef"]}, bin_attrs: {} }}: simple_ldap: close time.busy=19.5µs time.idle=7.71µs
2026-02-23T00:26:58.579019Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.579026Z TRACE cleanup: simple_ldap: close time.busy=2.29µs time.idle=5.33µs
test test_streaming_search ... ok
2026-02-23T00:26:58.579373Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.579666Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_update_no_record ... ok
test test_update_record ... ok
2026-02-23T00:26:58.581430Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.581797Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"], "cn": ["Jhon_Update"], "sn": ["Eliet_Update"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.581804Z DEBUG simple_ldap: Sucessfully deleted record result: "54e4c006-595b-4d90-bf5a-0613faf87395"
2026-02-23T00:26:58.581836Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"], "cn": ["Jhon_Update"], "sn": ["Eliet_Update"]}, bin_attrs: {} }}: simple_ldap: close time.busy=30.1µs time.idle=9.62µs
2026-02-23T00:26:58.581854Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "sn": ["Smith"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.581883Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "sn": ["Smith"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: close time.busy=19.5µs time.idle=10.3µs
2026-02-23T00:26:58.582132Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"sn": ["Hanks"], "cn": ["David"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.582157Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"sn": ["Hanks"], "cn": ["David"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"]}, bin_attrs: {} }}: simple_ldap: close time.busy=18.3µs time.idle=7.29µs
2026-02-23T00:26:58.582170Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.582179Z TRACE cleanup: simple_ldap: close time.busy=2.96µs time.idle=6.54µs
2026-02-23T00:26:58.582251Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"cn": ["Jhon_Update"], "uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"], "sn": ["Eliet_Update"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.582276Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com", attrs: {"cn": ["Jhon_Update"], "uid": ["e219fbc0-6df5-4bc3-a6ee-986843bb157e"], "sn": ["Eliet_Update"]}, bin_attrs: {} }}: simple_ldap: close time.busy=16.8µs time.idle=8.62µs
2026-02-23T00:26:58.582293Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.582303Z TRACE cleanup: simple_ldap: close time.busy=4.13µs time.idle=5.62µs
2026-02-23T00:26:58.582336Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.582344Z TRACE cleanup: simple_ldap: close time.busy=2.75µs time.idle=6.21µs
test test_streaming_search_paged ... ok
test test_add_users_to_group ... ok
2026-02-23T00:26:58.583560Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.584054Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.584402Z DEBUG simple_ldap: Sucessfully deleted record result: "784cfb27-4198-4705-a431-f60292834262"
test test_delete ... ok
2026-02-23T00:26:58.584854Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"], "cn": ["Sam"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.584892Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "sn": ["Smith"], "cn": ["Sam"]}, bin_attrs: {} }}: simple_ldap: close time.busy=29.2µs time.idle=9.25µs
2026-02-23T00:26:58.585226Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "cn": ["David"], "sn": ["Hanks"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.585249Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "cn": ["David"], "sn": ["Hanks"]}, bin_attrs: {} }}: simple_ldap: close time.busy=17.8µs time.idle=6.21µs
2026-02-23T00:26:58.585414Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.585424Z TRACE cleanup: simple_ldap: close time.busy=2.50µs time.idle=7.08µs
2026-02-23T00:26:58.585704Z DEBUG simple_ldap: Sucessfully created record result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.586335Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.587540Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.587590Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"], "cn": ["Sam"], "sn": ["Smith"]}, bin_attrs: {} }}: simple_ldap: close time.busy=35.7µs time.idle=15.8µs
2026-02-23T00:26:58.587644Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "sn": ["Hanks"], "cn": ["David"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.587669Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "sn": ["Hanks"], "cn": ["David"]}, bin_attrs: {} }}: simple_ldap: close time.busy=16.5µs time.idle=8.46µs
2026-02-23T00:26:58.587684Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.587695Z TRACE cleanup: simple_ldap: close time.busy=3.25µs time.idle=7.25µs
test test_get_members ... ok
2026-02-23T00:26:58.588058Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.589210Z DEBUG simple_ldap: Sucessfully created group result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_create_group ... ok
2026-02-23T00:26:58.589831Z DEBUG simple_ldap: Sucessfully updated dn result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
test test_remove_users_from_group ... ok
2026-02-23T00:26:58.590688Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=14a73d7b-b692-4e05-8a18-ffb2c451ee7d,ou=people,dc=example,dc=com", attrs: {"cn": ["I'm"], "sn": ["Updated"], "uid": ["14a73d7b-b692-4e05-8a18-ffb2c451ee7d"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.590728Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=14a73d7b-b692-4e05-8a18-ffb2c451ee7d,ou=people,dc=example,dc=com", attrs: {"cn": ["I'm"], "sn": ["Updated"], "uid": ["14a73d7b-b692-4e05-8a18-ffb2c451ee7d"]}, bin_attrs: {} }}: simple_ldap: close time.busy=29.7µs time.idle=11.1µs
2026-02-23T00:26:58.591811Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "sn": ["Smith"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.591853Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5,ou=people,dc=example,dc=com", attrs: {"cn": ["Sam"], "sn": ["Smith"], "uid": ["f92f4cb2-e821-44a4-bb13-b8ebadf4ecc5"]}, bin_attrs: {} }}: simple_ldap: close time.busy=29.0µs time.idle=13.9µs
2026-02-23T00:26:58.591914Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"sn": ["Hanks"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "cn": ["David"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.591941Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b,ou=people,dc=example,dc=com", attrs: {"sn": ["Hanks"], "uid": ["cb4bc91e-21d8-4bcc-bf6a-317b84c2e58b"], "cn": ["David"]}, bin_attrs: {} }}: simple_ldap: close time.busy=18.8µs time.idle=8.50µs
2026-02-23T00:26:58.591955Z TRACE cleanup: simple_ldap: new
2026-02-23T00:26:58.591964Z TRACE cleanup: simple_ldap: close time.busy=3.62µs time.idle=5.54µs
test test_add_users_to_group_preserves_existing_members ... ok
2026-02-23T00:26:58.592742Z DEBUG simple_ldap: Sucessfully updated dn result: LdapResult { rc: 0, matched: "", text: "", refs: [], ctrls: [] }
2026-02-23T00:26:58.593374Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=74e279d4-7892-4882-ad5d-c6205abdf908,ou=people,dc=example,dc=com", attrs: {"sn": ["Updated"], "cn": ["I'm"], "uid": ["74e279d4-7892-4882-ad5d-c6205abdf908"]}, bin_attrs: {} }}: simple_ldap: new
2026-02-23T00:26:58.593409Z DEBUG to_value{search_entry=SearchEntry { dn: "uid=74e279d4-7892-4882-ad5d-c6205abdf908,ou=people,dc=example,dc=com", attrs: {"sn": ["Updated"], "cn": ["I'm"], "uid": ["74e279d4-7892-4882-ad5d-c6205abdf908"]}, bin_attrs: {} }}: simple_ldap: close time.busy=27.8µs time.idle=8.21µs
test test_update_uid_record ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 26 tests
test src/../README.md - ReadmeDoctests (line 30) - compile ... ok
test src/lib.rs - (line 30) - compile ... ok
test src/lib.rs - LdapClient::add_users_to_group (line 1143) - compile ... ok
test src/lib.rs - LdapClient::authenticate (line 283) - compile ... ok
test src/lib.rs - LdapClient::create (line 825) - compile ... ok
test src/lib.rs - LdapClient::create_group (line 1080) - compile ... ok
test src/lib.rs - LdapClient::delete (line 1013) - compile ... ok
test src/lib.rs - LdapClient::get_associtated_groups (line 1441) - compile ... ok
test src/lib.rs - LdapClient::get_members (line 1219) - compile ... ok
test src/lib.rs - LdapClient::remove_users_from_group (line 1368) - compile ... ok
test src/lib.rs - LdapClient::search (line 430) - compile ... ok
test src/lib.rs - LdapClient::search_multi_valued (line 508) - compile ... ok
test src/lib.rs - LdapClient::streaming_search (line 589) - compile ... ok
test src/lib.rs - LdapClient::streaming_search_paged (line 715) - compile ... ok
test src/lib.rs - LdapClient::update (line 892) - compile ... ok
test src/pool.rs - pool::NonZeroUsize (line 24) - compile ... ok
test src/filter.rs - filter::AndFilter::add (line 44) ... ok
test src/simple_dn.rs - simple_dn::SimpleDN (line 28) ... ok
test src/lib.rs - (line 77) ... ok
test src/filter.rs - filter::LikeFilter::from (line 208) ... ok
test src/filter.rs - filter::ContainsFilter::from (line 247) ... ok
test src/filter.rs - filter::OrFilter::new (line 77) ... ok
test src/filter.rs - filter::AndFilter::new (line 22) ... ok
test src/filter.rs - filter::EqFilter::from (line 136) ... ok
test src/filter.rs - filter::OrFilter::add (line 99) ... ok
test src/filter.rs - filter::NotFilter::from (line 166) ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

all doctests ran in 1.69s; merged doctests compilation took 1.21s (passes)


___

## **CodeAnt-AI Description**
Fix group membership updates, handle escaped member DNs, and support multi-valued binary attributes

### What Changed
- Adding users to a group now preserves existing members instead of replacing them; subsequent add operations append members.
- Group member lookup correctly extracts attribute and value from member DNs that include escaped characters (commas, pluses, equals), so users with escaped RDNs are returned with the proper uid.
- Binary attributes with multiple values are exposed as sequences of byte arrays (Vec<Vec<u8>>) and can be decoded into byte-based types like Vec<Uuid>, allowing multi-valued binary fields to be read reliably.
- Test coverage and fixtures updated: new tests and LDIF fixture verify preserved membership, escaped-member DN parsing, and multi-valued binary mapping; package version bumped.

### Impact
`✅ Preserves existing group members when adding users`
`✅ Correctly lists members with escaped DN values`
`✅ Reads multi-valued binary attributes as byte arrays and UUIDs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
