### PR TITLE
Server Side Sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,18 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "8.0.1"
+version = "9.0.0"
 edition = "2024"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.89"
+bytes = "1.11.1"
 chumsky = "0.10.1"
 deadpool = { version = "0.12.2", optional = true }
-derive_more = { version = "2.0.1", features = ["debug", "display"] }
+derive_more = { version = "2.0.1", features = ["debug", "display", "try_from"] }
 futures = "0.3.31"
 itertools = "0.14.0"
 ldap3 = { version = "0.11.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ edition = "2024"
 [dependencies]
 async-trait = "0.1.89"
 bytes = "1.11.1"
-chumsky = "0.10.1"
-deadpool = { version = "0.12.2", optional = true }
+chumsky = "0.12.0"
+deadpool = { version = "0.13.0", optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display", "try_from"] }
 futures = "0.3.31"
 itertools = "0.14.0"
-ldap3 = { version = "0.11.5", default-features = false }
+ldap3 = { version = "0.12.1", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde-value = "0.7.0"
 serde_with = "3.12.0"
@@ -33,12 +33,12 @@ url = "2.5.4"
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
 anyhow = "1.0.98"
-rand = "0.9.0"
+rand = "0.10.0"
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
 uuid = { version = "1.16.0", features = ["v4", "serde"] }
 serde_with = "3.12.0"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = "0.3.23"
 serde_json = "1.0.142"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! - Search result [deserialization](#deserialization)
 //! - Connection pooling
 //! - Streaming search with native rust [`Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html)s
+//! - Server Side Sort
 //!
 //!
 //! ## Usage
@@ -141,7 +142,7 @@ use serde::{Deserialize, Serialize};
 use serde_value::Value;
 use std::{
     collections::{HashMap, HashSet},
-    fmt, iter,
+    fmt, iter, num::{NonZeroU16, NonZeroU32},
 };
 use thiserror::Error;
 use tracing::{Level, debug, error, info, instrument, warn};
@@ -561,130 +562,6 @@ impl LdapClient {
     /// Method will return a Stream. The stream will lazily fetch the results, resulting in a smaller
     /// memory footprint.
     ///
-    /// You might also want to take a look at [`streaming_search_paged()`].
-    ///
-    ///
-    /// # Arguments
-    ///
-    /// * `base` - The base DN to search for the user
-    /// * `scope` - The scope of the search
-    /// * `filter` - The filter to search for the user
-    /// * `attributes` - The attributes to return from the search
-    ///
-    ///
-    /// # Returns
-    ///
-    /// A stream that can be used to iterate through the search results.
-    ///
-    ///
-    /// ## Blocking drop caveat
-    ///
-    /// Dropping this stream may issue blocking network requests to cancel the search.
-    /// Running the stream to it's end will minimize the chances of this happening.
-    /// You should take this into account if latency is critical to your application.
-    ///
-    /// We're waiting for [`AsyncDrop`](https://github.com/rust-lang/rust/issues/126482) for implementing this properly.
-    ///
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use simple_ldap::{
-    ///     LdapClient, LdapConfig,
-    ///     filter::EqFilter,
-    ///     ldap3::Scope
-    /// };
-    /// use url::Url;
-    /// use serde::Deserialize;
-    /// use futures::StreamExt;
-    ///
-    ///
-    /// #[derive(Deserialize, Debug)]
-    /// struct User {
-    ///     uid: String,
-    ///     cn: String,
-    ///     sn: String,
-    /// }
-    ///
-    /// #[tokio::main]
-    /// async fn main(){
-    ///     let ldap_config = LdapConfig {
-    ///         bind_dn: String::from("cn=manager"),
-    ///         bind_password: String::from("password"),
-    ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
-    ///         connection_settings: None
-    ///     };
-    ///
-    ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
-    ///
-    ///     let name_filter = EqFilter::from(String::from("cn"), String::from("Sam"));
-    ///     let attributes = vec!["cn", "sn", "uid"];
-    ///
-    ///     let stream = client.streaming_search(
-    ///         "",
-    ///         Scope::OneLevel,
-    ///         &name_filter,
-    ///         attributes
-    ///     ).await.unwrap();
-    ///
-    ///     // The returned stream is not Unpin, so you may need to pin it to use certain operations,
-    ///     // such as next() below.
-    ///     let mut pinned_steam = Box::pin(stream);
-    ///
-    ///     while let Some(result) = pinned_steam.next().await {
-    ///         match result {
-    ///             Ok(element) => {
-    ///                 let user: User = element.to_record().unwrap();
-    ///                 println!("User: {:?}", user);
-    ///             }
-    ///             Err(err) => {
-    ///                 println!("Error: {:?}", err);
-    ///             }
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    ///
-    pub async fn streaming_search<'a, F, A, S>(
-        // This self reference  lifetime has some nuance behind it.
-        //
-        // In principle it could just be a value, but then you wouldn't be able to call this
-        // with a pooled client, as the deadpool `Object` wrapper only ever gives out references.
-        //
-        // The lifetime is needed to guarantee that the client is not returned to the pool before
-        // the returned stream is finished. This requirement is artificial. Internally the `ldap3` client
-        // just makes a copy. So this lifetime is here just to enforce correct pool usage.
-        &'a mut self,
-        base: &str,
-        scope: Scope,
-        filter: &F,
-        attributes: A,
-    ) -> Result<impl Stream<Item = Result<Record, Error>> + 'a + use<'a, F, A, S>, Error>
-    where
-        F: Filter,
-        A: AsRef<[S]> + Send + Sync + 'a,
-        S: AsRef<str> + Send + Sync + 'a,
-    {
-        let search_stream = self
-            .ldap
-            .streaming_search(base, scope, filter.filter().as_str(), attributes)
-            .await
-            .map_err(|ldap_error| {
-                Error::Query(
-                    format!("Error searching for record: {ldap_error:?}"),
-                    ldap_error,
-                )
-            })?;
-
-        to_native_stream(search_stream)
-    }
-
-    ///
-    /// This method is used to search multiple records from the LDAP server and results will be paginated.
-    /// Method will return a Stream. The stream will lazily fetch batches of results resulting in a smaller
-    /// memory footprint.
-    ///
     /// This is the recommended search method, especially if you don't know that the result set is going to be small.
     ///
     ///
@@ -694,12 +571,13 @@ impl LdapClient {
     /// * `scope` - The scope of the search
     /// * `filter` - The filter to search for the user
     /// * `attributes` - The attributes to return from the search
-    /// * `page_size` - The maximum number of records in a page
-    /// * `sort_by` - Sort the results using LDAP Server Side Sort.
+    /// * `page_size` - Fetch the results in pages. Recommended for large result sets.
+    ///   Uses the Simple Paged Results LDAP extension.
+    /// * `sort_by` - Sort the results using Server Side Sort LDAP extension.
     ///
     ///
     /// # Returns
-    ///
+    //
     /// A stream that can be used to iterate through the search results.
     ///
     ///
@@ -717,13 +595,14 @@ impl LdapClient {
     ///
     /// ```no_run
     /// use simple_ldap::{
-    ///     LdapClient, LdapConfig,
+    ///     LdapClient, LdapConfig, SortBy,
     ///     filter::EqFilter,
-    ///     ldap3::Scope
+    ///     ldap3::Scope,
     /// };
     /// use url::Url;
     /// use serde::Deserialize;
     /// use futures::{StreamExt, TryStreamExt};
+    /// use std::num::NonZero;
     ///
     ///
     /// #[derive(Deserialize, Debug)]
@@ -747,13 +626,20 @@ impl LdapClient {
     ///
     ///     let name_filter = EqFilter::from(String::from("cn"), String::from("Sam"));
     ///     let attributes = vec!["cn", "sn", "uid"];
+    ///     let sort = vec![
+    ///         SortBy {
+    ///             attribute: String::from("sn"),
+    ///             reverse: true
+    ///         }
+    ///     ];
     ///
-    ///     let stream = client.streaming_search_paged(
-    ///         "",
+    ///     let stream = client.streaming_search(
+    ///         "ou=people,dc=example,dc=com",
     ///         Scope::OneLevel,
     ///         &name_filter,
     ///         attributes,
-    ///         200 // The pagesize
+    ///         Some(NonZero::new(200).unwrap()), // The pagesize
+    ///         sort
     ///     ).await.unwrap();
     ///
     ///     // Map the search results to User type.
@@ -768,7 +654,7 @@ impl LdapClient {
     /// }
     /// ```
     ///
-    pub async fn streaming_search_paged<'a, F, A, S>(
+    pub async fn streaming_search<'a, F, A, S>(
         // This self reference  lifetime has some nuance behind it.
         //
         // In principle it could just be a value, but then you wouldn't be able to call this
@@ -782,7 +668,8 @@ impl LdapClient {
         scope: Scope,
         filter: &F,
         attributes: A,
-        page_size: i32,
+        // The internal adapter takes i32, but half of its range is invalid.
+        page_size: Option<NonZeroU16>,
         sort_by: Vec<SortBy>,
     ) -> Result<impl Stream<Item = Result<Record, Error>> + use<'a, F, A, S>, Error>
     where
@@ -791,6 +678,15 @@ impl LdapClient {
         A: AsRef<[S]> + Send + Sync + Clone + fmt::Debug + 'a,
         S: AsRef<str> + Send + Sync + Clone + fmt::Debug + 'a,
     {
+        // Define the needed adapters.
+
+        // Entries only is only needed with paging.
+        let (paging_adapter, entries_only_adapter) = page_size.map(|non_zero|
+                (PagedResults::new(non_zero.get().into()), EntriesOnly::new())
+            )
+            .map(|(page_adapter, entries_adapter)| (Box::new(page_adapter) as _, Box::new(entries_adapter) as _))
+            .unzip();
+
         // Empty vec just means that we won't use the search adapter.
         let sort_adapter: Option<Box<dyn Adapter<'a, S, A>>> = vec_to_option(sort_by)
             .map(ServerSideSort::new)
@@ -799,12 +695,14 @@ impl LdapClient {
             .map(|adapter| Box::new(adapter) as _);
 
         let maybe_adapters: Vec<Option<Box<dyn Adapter<'a, S, A>>>> = vec![
-            Some(Box::new(EntriesOnly::new())),
             // Sort needs to be before paging, so that it's control will be included in all the page requests.
             sort_adapter,
-            Some(Box::new(PagedResults::new(page_size))),
+            entries_only_adapter,
+            paging_adapter,
         ];
 
+        // This might end up as no adapters but that's perfectly fine too.
+        // Internally the non adapted streaming search would anyway just call the same thing with an empty adapter list.
         let adapters: Vec<_> = maybe_adapters.into_iter().flatten().collect();
 
         let search_stream = self
@@ -1277,8 +1175,8 @@ impl LdapClient {
         attributes: A,
     ) -> Result<Vec<T>, Error>
     where
-        A: AsRef<[S]> + Send + Sync + 'a,
-        S: AsRef<str> + Send + Sync + 'a,
+        A: AsRef<[S]> + Send + Sync + Clone + fmt::Debug + 'a,
+        S: AsRef<str> + Send + Sync + Clone + fmt::Debug + 'a,
         T: for<'de> serde::Deserialize<'de>,
     {
         let search = self
@@ -1341,7 +1239,7 @@ impl LdapClient {
             .for_each(|eq| or_filter.add(Box::new(eq)));
 
         let result = self
-            .streaming_search(base_dn, scope, &or_filter, attributes)
+            .streaming_search(base_dn, scope, &or_filter, attributes, None, Vec::new())
             .await;
 
         let mut members = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # simple-ldap
 //!
-//! This is a high-level LDAP client library created by wrapping the rust LDAP3 clinet.
+//! This is a high-level LDAP client library created by wrapping the rust LDAP3 client.
 //! This provides high-level functions that helps to interact with LDAP.
 //!
 //!
@@ -142,7 +142,7 @@ use serde::{Deserialize, Serialize};
 use serde_value::Value;
 use std::{
     collections::{HashMap, HashSet},
-    fmt, iter, num::{NonZeroU16, NonZeroU32},
+    fmt, iter, num::NonZeroU16,
 };
 use thiserror::Error;
 use tracing::{Level, debug, error, info, instrument, warn};
@@ -252,11 +252,11 @@ impl LdapClient {
     /// including open streams. So make sure that you're really good to close.
     ///
     /// Closing an LDAP connection with an unbind is *a curtesy.*
-    /// It's fine to skip it, and because of the async hurdless outlined above,
+    /// It's fine to skip it, and because of the async hurdles outlined above,
     /// I would perhaps even recommend it.
     // Consuming self to prevent accidental use after unbind.
     // This also conveniently prevents calling this with pooled clients, as the
-    // wrapper `Object` prohibiths moving.
+    // wrapper `Object` prohibits moving.
     pub async fn unbind(mut self) -> Result<(), Error> {
         match self.ldap.unbind().await {
             Ok(_) => Ok(()),
@@ -491,7 +491,8 @@ impl LdapClient {
     ///
     /// Search a single value from the LDAP server. The search is performed using the provided filter.
     /// The filter should be a filter that matches a single record. if the filter matches multiple users, an error is returned.
-    /// This operatrion is useful when records has multi-valued attributes.
+    /// This operation is useful when records has multi-valued attributes.
+    ///
     ///
     /// # Arguments
     ///
@@ -781,7 +782,7 @@ impl LdapClient {
             return Err(Error::Create(format!("Error saving record: {err:?}"), err));
         }
         let res = save.unwrap();
-        debug!("Sucessfully created record result: {:?}", res);
+        debug!("Successfully created record result: {:?}", res);
         Ok(())
     }
 
@@ -902,7 +903,7 @@ impl LdapClient {
             }
 
             let res = dn_update.unwrap();
-            debug!("Sucessfully updated dn result: {:?}", res);
+            debug!("Successfully updated dn result: {:?}", res);
         }
 
         Ok(())
@@ -971,7 +972,7 @@ impl LdapClient {
                 }
             }
         }
-        debug!("Sucessfully deleted record result: {:?}", uid);
+        debug!("Successfully deleted record result: {:?}", uid);
         Ok(())
     }
 
@@ -1034,7 +1035,7 @@ impl LdapClient {
             return Err(Error::Create(format!("Error creating group: {err:?}"), err));
         }
         let res = save.unwrap();
-        debug!("Sucessfully created group result: {:?}", res);
+        debug!("Successfully created group result: {:?}", res);
         Ok(())
     }
 
@@ -1667,7 +1668,7 @@ where
     async fn cleanup(&mut self) -> () {
         // Calling this might not be strictly necessary,
         // but it's probably expected so let's just do it.
-        // I don't think this does any networkig most of the time.
+        // I don't think this does any networking most of the time.
         let finish_result = self.search_stream.finish().await;
 
         match finish_result.success() {
@@ -1757,7 +1758,7 @@ impl Record {
     /// Create a new Record object with single valued attributes.
     /// This is essentially parsing the response records into usable types.
     //
-    // This is kind of missnomer, as we aren't creating records here.
+    // This is kind of misnomer, as we aren't creating records here.
     // Perhaps something like "deserialize" would fit better?
     pub fn to_record<T: for<'b> serde::Deserialize<'b>>(self) -> Result<T, Error> {
         to_value(self.search_entry)

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,0 +1,11 @@
+//! This module implements the Server Side Sort control in `ldap3`'s `Adapter` framework.
+
+// This is all heavily inspired by the `PagedResults` implementation.
+
+pub(crate) mod adapter;
+
+// Control is the low level component of the implementation.
+mod control;
+
+const SERVER_SIDE_SORT_REQUEST_OID: &str = "1.2.840.113556.1.4.473";
+const SERVER_SIDE_SORT_RESPONSE_OID: &str = "1.2.840.113556.1.4.474";

--- a/src/sort/adapter.rs
+++ b/src/sort/adapter.rs
@@ -1,5 +1,5 @@
 //! This module implements Server Side Sort (SSS) search extension
-//! as described in [RFC 2891](datatracker.ietf.org/doc/rfc2891/).
+//! as described in [RFC 2891](https://datatracker.ietf.org/doc/rfc2891/).
 
 use async_trait::async_trait;
 use itertools::Itertools;

--- a/src/sort/adapter.rs
+++ b/src/sort/adapter.rs
@@ -1,0 +1,193 @@
+//! This module implements Server Side Sort (SSS) search extension
+//! as described in [RFC 2891](datatracker.ietf.org/doc/rfc2891/).
+
+use async_trait::async_trait;
+use itertools::Itertools;
+use ldap3::{
+    LdapError, LdapResult, ResultEntry, Scope, SearchStream,
+    adapters::{Adapter, SoloMarker},
+    controls::{Control, MakeCritical, RawControl},
+};
+use std::{fmt::Debug, mem};
+use thiserror::Error;
+use tracing::debug;
+
+use crate::sort::{
+    SERVER_SIDE_SORT_REQUEST_OID, SERVER_SIDE_SORT_RESPONSE_OID,
+    control::{self, ServerSideSortResponse, SortResult},
+};
+
+/// Search adapter for sorting the results serverside.
+#[derive(Debug, Clone)]
+pub(crate) struct ServerSideSort {
+    /// The server evaluates these sort criteria in order.
+    /// If there's a tie, the next criteria will be consulted.
+    ///
+    ///
+    /// Invariant: This vec doesn't contain elements with the same `attribute` field.
+    //
+    //  (It shouldn't be empty either but that's not enforced at this level.)
+    sorts: Vec<SortBy>,
+}
+
+#[derive(Debug, Error)]
+#[error("Attributes {} occur more than once in the sort list.",
+    attributes.iter().format(", ")
+)]
+pub struct DuplicateSortAttributes {
+    attributes: Vec<String>,
+}
+
+impl ServerSideSort {
+    /// Create new adapter instance.
+    ///
+    /// Duplicate attributes aren't allowed.
+    ///
+    /// Servers are allowed to limit the amount of attributes to sort by.
+    /// In this case the search should just err.
+    pub fn new(sorts: Vec<SortBy>) -> Result<Self, DuplicateSortAttributes> {
+        // First validate the inputs.
+        let duplicates = sorts
+            .iter()
+            .map(|SortBy { attribute, .. }| attribute)
+            .duplicates()
+            .collect_vec();
+
+        if !duplicates.is_empty() {
+            let attributes = duplicates.into_iter().map(ToOwned::to_owned).collect();
+            Err(DuplicateSortAttributes { attributes })
+        }
+        // Everything is good in this branch.
+        else {
+            Ok(ServerSideSort { sorts })
+        }
+    }
+}
+
+/// A sort directive
+///
+// Not exposing the `orderingRule` as I don't know how it's supposed to work.
+#[derive(Debug, Clone)]
+pub struct SortBy {
+    /// Name of the attribute to sort by.
+    pub attribute: String,
+    /// Should the ordering be reversed?
+    pub reverse: bool,
+}
+
+/// Can be used by itself.
+impl SoloMarker for ServerSideSort {}
+
+#[async_trait]
+impl<'a, S, A> Adapter<'a, S, A> for ServerSideSort
+where
+    S: AsRef<str> + Clone + Debug + Send + Sync + 'a,
+    A: AsRef<[S]> + Clone + Debug + Send + Sync + 'a,
+{
+    async fn start(
+        &mut self,
+        stream: &mut SearchStream<'a, S, A>,
+        base: &str,
+        scope: Scope,
+        filter: &str,
+        attrs: A,
+    ) -> ldap3::result::Result<()> {
+        let stream_ldap = stream.ldap_handle();
+
+        // Check that SSS isn't defined already.
+        let sort_control_already_defined = stream_ldap.controls.as_ref().is_some_and(|vec| {
+            vec.iter()
+                .any(|control| control.ctype == SERVER_SIDE_SORT_REQUEST_OID)
+        });
+        if sort_control_already_defined {
+            return Err(LdapError::AdapterInit(String::from(
+                "found Server Side Sort control in op set already",
+            )));
+        }
+
+        // No need to keep these around in the adapter.
+        let sorts = mem::take(&mut self.sorts);
+        let new_control = control::ServerSideSortRequest {
+            // Convert the sort args to control parts.
+            sort_key_list: sorts.into_iter().map_into().collect(),
+        } // We want the search to fail if sorting isn't supported.
+        .critical();
+
+        // Adding the control to the search.
+        stream_ldap
+            .controls
+            .get_or_insert_default()
+            .push(new_control.into());
+
+        // Continue the chain.
+        stream.start(base, scope, filter, attrs).await
+    }
+
+    async fn next(
+        &mut self,
+        stream: &mut SearchStream<'a, S, A>,
+    ) -> ldap3::result::Result<Option<ResultEntry>> {
+        match stream.next().await? {
+            Some(result_entry) => {
+                // It's a little unclear to me whether I should be looking at this res in `stream`
+                // or the result_entry directly? Are the controls just the same?
+                let sss_control = stream.res.as_ref().and_then(
+                    |LdapResult {
+                         ctrls: controls, ..
+                     }| get_response_control(controls.as_slice()),
+                );
+
+                match sss_control {
+                    Some(ServerSideSortResponse {
+                        sort_result: SortResult::Success,
+                        ..
+                    }) => {
+                        // All good, passing on the result.
+                        Ok(Some(result_entry))
+                    }
+                    Some(ServerSideSortResponse { sort_result, .. }) => {
+                        panic!(
+                            "Server side sort result was {sort_result:?}. This should never be the case in this branch as the control was set to critical and so should have caused an error earlier."
+                        )
+                    }
+                    None => {
+                        debug!("No server side sort response control.");
+                        Ok(Some(result_entry))
+                    }
+                }
+            }
+            // I suppose we could check for the control here too, but my understanding is that it's only
+            // used when there are actually results.
+            None => Ok(None),
+        }
+    }
+
+    async fn finish(&mut self, stream: &mut SearchStream<'a, S, A>) -> LdapResult {
+        // Just logging here
+
+        let result = stream.finish().await;
+
+        let sss_control = get_response_control(result.ctrls.as_slice());
+
+        match sss_control {
+            None => debug!("No Server Side Sort control in the final result"),
+            Some(control) => debug!("The final Server Side Sort control: {control:?}"),
+        };
+
+        result
+    }
+}
+
+// Get and parse the SSS response control if there is one.
+//
+// My understanding from RFC 2981 section 2 is that whenever there is at least one search result,
+// there should also be the SSS response control.
+fn get_response_control(controls: &[Control]) -> Option<ServerSideSortResponse> {
+    controls
+        .iter()
+        // Control type isn't parsed since this control is implemented outside ldap3
+        // so we're just working with the raw values.
+        .map(|Control(_, raw)| raw)
+        .find(|raw| raw.ctype == SERVER_SIDE_SORT_RESPONSE_OID)
+        .map(RawControl::parse)
+}

--- a/src/sort/control.rs
+++ b/src/sort/control.rs
@@ -1,0 +1,208 @@
+//! The low level control implementation of Server Side Sort (SSS)
+//!
+
+use bytes::BytesMut;
+use derive_more::TryFrom;
+use itertools::Itertools;
+use ldap3::{
+    asn1::{
+        ASNTag, Boolean, OctetString, Sequence, Tag, TagClass, Types, parse_tag, parse_uint, write,
+    },
+    controls::{ControlParser, MakeCritical, RawControl},
+};
+
+use crate::sort::{SERVER_SIDE_SORT_REQUEST_OID, adapter::SortBy};
+
+/// Request control for SSS.
+pub(crate) struct ServerSideSortRequest {
+    pub sort_key_list: Vec<SortKey>,
+}
+
+/// May be critical.
+///
+/// RFC 2891 1.1
+impl MakeCritical for ServerSideSortRequest {}
+
+impl From<ServerSideSortRequest> for RawControl {
+    fn from(value: ServerSideSortRequest) -> Self {
+        let tagged = Tag::Sequence(Sequence {
+            // Just converting the vec elements to tags.
+            inner: value.sort_key_list.into_iter().map_into().collect(),
+            ..Default::default()
+        })
+        .into_structure();
+
+        // We could try to guess the required capacity.
+        let mut buffer = BytesMut::new();
+        write::encode_into(&mut buffer, tagged).expect("Encoding should pass");
+
+        RawControl {
+            ctype: SERVER_SIDE_SORT_REQUEST_OID.to_owned(),
+            crit: false,
+            val: Some(buffer.into()),
+        }
+    }
+}
+
+/// An individual sort key, i.e. a piece of the control specifying one sort criterion.
+#[derive(Debug)]
+pub(crate) struct SortKey {
+    /// Name of the attribute to sort by.
+    pub attribute_type: String,
+    /// A `MatchingRuleId`, as defined in section 4.1.9 of LDAPv3 spec (or so I hear)
+    pub ordering_rule: Option<String>,
+    /// Should the ordering be reversed?
+    pub reverse_order: bool,
+}
+
+impl From<SortBy> for SortKey {
+    fn from(value: SortBy) -> Self {
+        SortKey {
+            attribute_type: value.attribute,
+            ordering_rule: None,
+            reverse_order: value.reverse,
+        }
+    }
+}
+
+// Implicit tags
+const ORDERING_RULE_TAG: u64 = 0;
+const REVERSE_ORDER_TAG: u64 = 1;
+
+/// It will be a sequence.
+impl From<SortKey> for Tag {
+    fn from(value: SortKey) -> Self {
+        let iterator = [
+            // AttributeDescription
+            Some(Tag::OctetString(OctetString {
+                inner: value.attribute_type.into(),
+                ..Default::default()
+            })),
+            value.ordering_rule.map(|rule| {
+                Tag::OctetString(OctetString {
+                    id: ORDERING_RULE_TAG,
+                    class: TagClass::Context,
+                    inner: rule.into(),
+                })
+            }),
+            Some(Tag::Boolean(Boolean {
+                id: REVERSE_ORDER_TAG,
+                class: TagClass::Context,
+                inner: value.reverse_order,
+            })),
+        ]
+        .into_iter()
+        .flatten(); // The Options
+
+        Tag::Sequence(Sequence {
+            inner: iterator.collect(),
+            ..Sequence::default()
+        })
+    }
+}
+
+/*******************************
+ *  Then the response control  *
+ *******************************/
+
+/// Request control for SSS.
+#[derive(Debug)]
+pub(crate) struct ServerSideSortResponse {
+    pub sort_result: SortResult,
+
+    /// This may contain the name of a troublesome attribute if the sort fails.
+    ///
+    /// RFC 2891 2:
+    ///
+    /// > Optionally, the server MAY set the attributeType to the first attribute
+    /// > type specified in the SortKeyList that was in error. The client SHOULD
+    /// > ignore the attributeType field if the sortResult is success.
+    ///
+    /// [0] AttributeDescription OPTIONAL
+    #[expect(
+        dead_code,
+        reason = "It's here per the spec. May have some uses in error cases."
+    )]
+    pub attribute_type: Option<String>,
+}
+
+/// Potential results to SSS.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, TryFrom)]
+#[try_from(repr)]
+// Unnecessary big size but it matches what the parser spits out.
+#[repr(u64)]
+pub(crate) enum SortResult {
+    /// Results are sorted
+    Success = 0,
+    /// Server internal failure
+    OperationsError = 1,
+    /// Timelimit reached before sorting was completed
+    TimeLimitExceeded = 3,
+    /// Refused to return sorted results via insecure protocol
+    StrongAuthRequired = 8,
+    /// Too many matching entries for the server to sort
+    AdminLimitExceeded = 11,
+    /// Unrecognized attribute type in sort key
+    NoSuchAttribute = 16,
+    /// Unrecognized or inappropriate matching rule in sort key
+    InappropriateMatching = 18,
+    /// Refused to return sorted results to this client
+    InsufficientAccessRights = 50,
+    /// Too busy to process
+    Busy = 51,
+    /// Unable to sort
+    UnwillingToPerform = 53,
+    Other = 80,
+}
+
+const ATTRIBUTE_TYPE_TAG: u64 = 0;
+
+impl ControlParser for ServerSideSortResponse {
+    fn parse(val: &[u8]) -> Self {
+        let mut sequence_components = match parse_tag(val) {
+            Ok((_, tag)) => tag,
+            _ => panic!("failed to parse server side sort response control components"),
+        }
+        .expect_constructed()
+        .expect("server side sort results components")
+        .into_iter();
+
+        let raw_sort_result = sequence_components
+            .next()
+            .expect("server side sort element 1")
+            .match_class(TagClass::Universal)
+            .and_then(|tag| tag.match_id(Types::Enumerated as u64))
+            .and_then(|tag| tag.expect_primitive())
+            .expect("sortResult");
+
+        let (_, numeric_sort_result) =
+            parse_uint(raw_sort_result.as_slice()).expect("should have been a sort result");
+
+        let sort_result = SortResult::try_from(numeric_sort_result)
+            .expect("should have been a valid sort result code");
+
+        // The RFC tells us to ignore the other field if the result is a success.
+        if sort_result == SortResult::Success {
+            ServerSideSortResponse {
+                sort_result,
+                attribute_type: None,
+            }
+        } else {
+            // This is an optional field even in the case of error result.
+            let attribute_type = sequence_components
+                .next()
+                .and_then(|tag| tag.match_class(TagClass::Context))
+                .and_then(|tag| tag.match_id(ATTRIBUTE_TYPE_TAG))
+                .and_then(|tag| tag.expect_primitive())
+                // I think it should be a string.
+                .map(String::from_utf8)
+                .transpose()
+                .expect("should be an AttributeType Description");
+
+            ServerSideSortResponse {
+                sort_result,
+                attribute_type,
+            }
+        }
+    }
+}

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -86,7 +86,8 @@ pub struct User {
 
 #[derive(Deserialize)]
 pub struct MultiValueUser {
-    pub _dn: SimpleDN,
+    #[expect(dead_code, reason = "Having this here will still test the deserialization.")]
+    pub dn: SimpleDN,
     #[serde(rename = "objectClass")]
     pub object_class: Vec<String>,
     pub uid: Vec<String>,

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -41,7 +41,7 @@
 use anyhow::anyhow;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
-use rand::Rng;
+use rand::RngExt;
 use serde::Deserialize;
 use std::{collections::HashSet, num::{NonZero, NonZeroU16}, ops::DerefMut, str::FromStr, sync::Once};
 use tracing::Level;

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -78,6 +78,18 @@ async fn test_streaming_search_paged() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sorted_paged_search() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::sorted_paged_search(Box::new(client)).await
+}
+
+#[tokio::test]
+async fn sorted_paged_search_reverse() -> anyhow::Result<()> {
+    let client = get_test_client().await?;
+    client_test_cases::sorted_paged_search_reverse(Box::new(client)).await
+}
+
+#[tokio::test]
 async fn test_search_stream_drop() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_stream_drop(Box::new(client)).await

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -66,15 +66,15 @@ async fn test_update_uid_record() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_streaming_search() -> anyhow::Result<()> {
+async fn streaming_search() -> anyhow::Result<()> {
     let client = get_test_client().await?;
-    client_test_cases::test_streaming_search(Box::new(client)).await
+    client_test_cases::streaming_search(Box::new(client)).await
 }
 
 #[tokio::test]
-async fn test_streaming_search_paged() -> anyhow::Result<()> {
+async fn streaming_search_paged() -> anyhow::Result<()> {
     let client = get_test_client().await?;
-    client_test_cases::test_streaming_search_paged(Box::new(client)).await
+    client_test_cases::streaming_search_paged(Box::new(client)).await
 }
 
 #[tokio::test]

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -83,13 +83,13 @@ async fn test_update_uid_record() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_streaming_search() -> anyhow::Result<()> {
-    dispatch_parallel_test(client_test_cases::test_streaming_search).await
+async fn streaming_search() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::streaming_search).await
 }
 
 #[tokio::test]
-async fn test_streaming_search_paged() -> anyhow::Result<()> {
-    dispatch_parallel_test(client_test_cases::test_streaming_search_paged).await
+async fn streaming_search_paged() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::streaming_search_paged).await
 }
 
 #[tokio::test]

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -93,6 +93,16 @@ async fn test_streaming_search_paged() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sorted_paged_search() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::sorted_paged_search).await
+}
+
+#[tokio::test]
+async fn sorted_paged_search_reverse() -> anyhow::Result<()> {
+    dispatch_parallel_test(client_test_cases::sorted_paged_search_reverse).await
+}
+
+#[tokio::test]
 async fn test_search_stream_drop() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_stream_drop).await
 }


### PR DESCRIPTION
## **User description**
Adding support for the LDAP Server Side Sort extension defined in [RFC 2891](https://datatracker.ietf.org/doc/rfc2891/).

This is done by implementing a couple new controls, a corresponding adapter, and then exposing it in the public API. The API part requires still some thought. Open to suggestions!

I might try to upstream the low level bits to `ldap3` crate at some point too, but lets just start here. This will be an invisible change if it does happen in the future.

fixes: #52


___

## **CodeAnt-AI Description**
Support Server Side Sort and unified streaming_search with optional paging

### What Changed
- Added Server Side Sort (RFC 2891) support so LDAP searches can request the server to sort results before returning them.
- Replaced the old paging-only API with a single streaming_search that accepts an optional page size and a sort-by list; paging now uses the Simple Paged Results extension and sort controls are applied before paging.
- Exported a SortBy argument type for callers to request server-side sorting (including reversed order); duplicate sort attributes are rejected early.
- Tests updated and added to exercise paged and sorted searches; examples in docs and test helpers updated to use the new streaming_search signature.
- Minor user-facing fixes: README/features updated to list Server Side Sort, several spelling fixes in logs/documentation, and the package version bumped to 9.0.0.

### Impact
`✅ Sorted paged searches`
`✅ Server-side sorting for large result sets`
`✅ Fewer client-side memory spikes during large searches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
