### PR TITLE
Better stream cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "9.0.0"
+version = "10.0.0"
 edition = "2024"
 
 
@@ -25,6 +25,9 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde-value = "0.7.0"
 serde_with = "3.12.0"
 thiserror = "2.0.12"
+# ldap3 is already depending on tokio so we aren't adding much.
+# Multithread is needed for the blocking calls in stream destructor.
+tokio = { version = "1.44.2", features = ["rt-multi-thread"] }
 tracing = "0.1.41"
 url = "2.5.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 [dependencies]
 async-trait = "0.1.89"
 bytes = "1.11.1"
-chumsky = "0.12.0"
+chumsky = "0.13.0"
 deadpool = { version = "0.13.0", optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display", "try_from"] }
 futures = "0.3.31"
@@ -33,7 +33,7 @@ url = "2.5.4"
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
 anyhow = "1.0.98"
-rand = "0.10.0"
+rand = "0.10.1"
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
 uuid = { version = "1.16.0", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ struct User {
 }
 
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main(){
     let ldap_config = LdapConfig {
         bind_dn: String::from("cn=manager"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,10 +134,9 @@
 //! * `pool` - Enable connection pooling
 //!
 
-use futures::{Stream, StreamExt, executor::block_on, stream};
+use futures::{Stream, StreamExt};
 use ldap3::{
-    Ldap, LdapConnAsync, LdapConnSettings, LdapError, LdapResult, Mod, Scope, SearchEntry,
-    SearchStream, StreamState,
+    Ldap, LdapConnAsync, LdapConnSettings, LdapError, Mod, Scope, SearchEntry,
     adapters::{Adapter, EntriesOnly, PagedResults},
 };
 use serde::{Deserialize, Serialize};
@@ -147,7 +146,7 @@ use std::{
     fmt, iter, num::NonZeroU16,
 };
 use thiserror::Error;
-use tracing::{Level, debug, error, info, instrument, warn};
+use tracing::{Level, debug, error, instrument, warn};
 use url::Url;
 
 use filter::{AndFilter, EqFilter, Filter, OrFilter};
@@ -158,10 +157,13 @@ pub mod filter;
 pub mod pool;
 pub mod simple_dn;
 mod sort;
+mod stream;
 // Export the main type of the module right here in the root.
 pub use simple_dn::SimpleDN;
 // Used as an argument in the public API.
 pub use sort::adapter::SortBy;
+
+use crate::stream::to_native_stream;
 
 // Would likely be better if we could avoid re-exporting this.
 // I suspect it's only used in some configs?
@@ -1625,126 +1627,6 @@ fn map_to_single_value_bin(attra_values: Option<Vec<u8>>) -> serde_value::Value 
     }
 }
 
-/// This wrapper exists solely for the purpose of runnig some cleanup in `drop()`.
-///
-/// This should be refactored to implement `AsyncDrop` when it gets stabilized:
-/// https://github.com/rust-lang/rust/issues/126482
-struct StreamDropWrapper<'a, S, A>
-where
-    S: AsRef<str> + Send + Sync + 'a,
-    A: AsRef<[S]> + Send + Sync + 'a,
-{
-    pub search_stream: SearchStream<'a, S, A>,
-}
-
-impl<'a, S, A> Drop for StreamDropWrapper<'a, S, A>
-where
-    S: AsRef<str> + Send + Sync + 'a,
-    A: AsRef<[S]> + Send + Sync + 'a,
-{
-    fn drop(&mut self) {
-        // Making this blocking call in drop is suboptimal.
-        // We should use async-drop, when it's stabilized:
-        // https://github.com/rust-lang/rust/issues/126482
-        block_on(self.cleanup());
-    }
-}
-
-impl<'a, S, A> StreamDropWrapper<'a, S, A>
-where
-    S: AsRef<str> + Send + Sync + 'a,
-    A: AsRef<[S]> + Send + Sync + 'a,
-{
-    ///
-    /// Cleanup the stream. This method should be called when dropping the stream.
-    ///
-    /// This method will cleanup the stream and close the connection.
-    ///
-    ///
-    /// # Errors
-    ///
-    /// No errors are returned, as this is meant to be called from `drop()`.
-    /// Traces are emitted though.
-    ///
-    #[instrument(level = Level::TRACE, skip_all)]
-    async fn cleanup(&mut self) -> () {
-        // Calling this might not be strictly necessary,
-        // but it's probably expected so let's just do it.
-        // I don't think this does any networking most of the time.
-        let finish_result = self.search_stream.finish().await;
-
-        match finish_result.success() {
-            Ok(_) => (), // All good.
-            // This is returned if the stream is cancelled in the middle.
-            // Which is fine for us.
-            // https://ldap.com/ldap-result-code-reference-client-side-result-codes/#rc-userCanceled
-            Err(LdapError::LdapResult {
-                result: LdapResult { rc: 88, .. },
-            }) => (),
-            Err(finish_err) => error!("The stream finished with an error: {finish_err}"),
-        }
-
-        match self.search_stream.state() {
-            // Stream processed to the end, no need to cancel the operation.
-            // This should be the common case.
-            StreamState::Done | StreamState::Closed => (),
-            StreamState::Error => {
-                error!(
-                    "Stream is in Error state. Not trying to cancel it as it could do more harm than good."
-                );
-            }
-            StreamState::Fresh | StreamState::Active => {
-                info!("Stream is still open. Issuing cancellation to the server.");
-                let msgid = self.search_stream.ldap_handle().last_id();
-                let result = self.search_stream.ldap_handle().abandon(msgid).await;
-
-                match result {
-                    Ok(_) => (),
-                    Err(err) => {
-                        error!("Error abandoning search result: {:?}", err);
-                        ()
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// A helper to create native rust streams out of `ldap3::SearchStream`s.
-fn to_native_stream<'a, S, A>(
-    ldap3_stream: SearchStream<'a, S, A>,
-) -> Result<impl Stream<Item = Result<Record, Error>> + 'a + use<'a, S, A>, Error>
-where
-    S: AsRef<str> + Send + Sync + 'a,
-    A: AsRef<[S]> + Send + Sync + 'a,
-{
-    // This will handle stream cleanup.
-    let stream_wrapper = StreamDropWrapper {
-        search_stream: ldap3_stream,
-    };
-
-    // Produce the steam itself by unfolding.
-    let stream = stream::try_unfold(stream_wrapper, async |mut search| {
-        match search.search_stream.next().await {
-            // In the middle of the stream. Produce the next result.
-            Ok(Some(result_entry)) => Ok(Some((
-                Record {
-                    search_entry: SearchEntry::construct(result_entry),
-                },
-                search,
-            ))),
-            // Stream is done.
-            Ok(None) => Ok(None),
-            Err(ldap_error) => Err(Error::Query(
-                format!("Error getting next record: {ldap_error:?}"),
-                ldap_error,
-            )),
-        }
-    });
-
-    Ok(stream)
-}
-
 /// The Record struct is used to map the search result to a struct.
 /// The Record struct has a method to_record which will map the search result to a struct.
 /// The Record struct has a method to_multi_valued_record which will map the search result to a struct with multi valued attributes.
@@ -2004,7 +1886,7 @@ mod tests {
     }
     /// Get the binary and hyphenated string representations of an UUID for testing.
     fn get_binary_uuid() -> (Vec<u8>, String) {
-        // Exaple grabbed from uuid docs:
+        // Example grabbed from uuid docs:
         // https://docs.rs/uuid/latest/uuid/struct.Uuid.html#method.from_bytes
         let bytes = vec![
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,11 @@
 //! Adding `simple_ldap` as a dependency to your project:
 //!
 //! ```commandline
+//! cargo add tokio --features rt-multi-thread
 //! cargo add simple-ldap
 //! ```
+//!
+//! Multithreaded executor is required.
 //!
 //! Most functionalities are defined on the [`LdapClient`] type. Have a look at the docs.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,6 @@ impl LdapClient {
     /// We're waiting for [`AsyncDrop`](https://github.com/rust-lang/rust/issues/126482) for implementing this properly.
     ///
     ///
-    ///
     /// # Example
     ///
     /// ```no_run
@@ -1522,7 +1521,7 @@ fn to_signle_value<T: for<'a> Deserialize<'a>>(search_entry: SearchEntry) -> Res
         .map_err(|err| Error::Mapping(format!("Error converting search result to object, {err:?}")))
 }
 
-#[instrument(level = Level::DEBUG)]
+#[instrument(level = Level::TRACE)]
 fn to_value<T: for<'a> Deserialize<'a>>(search_entry: SearchEntry) -> Result<T, Error> {
     let string_attributes = search_entry
         .attrs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,8 @@ use serde::{Deserialize, Serialize};
 use serde_value::Value;
 use std::{
     collections::{HashMap, HashSet},
-    fmt, iter, num::NonZeroU16,
+    fmt, iter,
+    num::NonZeroU16,
 };
 use thiserror::Error;
 use tracing::{Level, debug, error, instrument, warn};
@@ -688,10 +689,11 @@ impl LdapClient {
         // Define the needed adapters.
 
         // Entries only is only needed with paging.
-        let (paging_adapter, entries_only_adapter) = page_size.map(|non_zero|
-                (PagedResults::new(non_zero.get().into()), EntriesOnly::new())
-            )
-            .map(|(page_adapter, entries_adapter)| (Box::new(page_adapter) as _, Box::new(entries_adapter) as _))
+        let (paging_adapter, entries_only_adapter) = page_size
+            .map(|non_zero| (PagedResults::new(non_zero.get().into()), EntriesOnly::new()))
+            .map(|(page_adapter, entries_adapter)| {
+                (Box::new(page_adapter) as _, Box::new(entries_adapter) as _)
+            })
             .unzip();
 
         // Empty vec just means that we won't use the search adapter.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,8 +1,9 @@
 //! Native rust streams for streaming searches
 //!
 
-use futures::{Stream, executor::block_on};
+use futures::Stream;
 use ldap3::{LdapError, LdapResult, SearchEntry, SearchStream, StreamState};
+use tokio::{runtime::Handle, task::block_in_place};
 use tracing::{Level, error, info, instrument};
 
 use crate::{Error, Record};
@@ -24,13 +25,7 @@ where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,
 {
-    /// ⚠️ Deadlock risk
-    ///
-    /// Sporadic async deadlocks have been encountered here.
-    /// Some version of [Futurelock](https://rfd.shared.oxide.computer/rfd/0609),
-    /// I believe it's due to ldap3 storing stream adaptors inside tokio mutexes
-    /// in combination with some future structures.
-    ///
+
     /// Anyway nowadays we do most cleanup in the stream end, so this does nothing.
     /// The risk still exists if the stream is dropped mid way though.
     fn drop(&mut self) {
@@ -41,7 +36,18 @@ where
                 // Making this blocking call in drop is suboptimal.
                 // We should use async-drop, when it's stabilized:
                 // https://github.com/rust-lang/rust/issues/126482
-                match block_on(self.cleanup()) {
+                //
+                // Previously we used `futures::block_on()` but that ran the risk of deadlocks
+                // (not entirely clear why). The client object is already guaranteed to be in a tokio runtime,
+                // and so the lifetime `'a` also guarantees that we are now in a tokio managed thread.
+                // Thus we can run some async code with block_in_place().
+                // This does necessitate that we're in a multithread executor though.
+                let result = block_in_place(|| {
+                    Handle::current().block_on(async move {
+                        self.cleanup().await
+                    })
+                });
+                match result {
                     Ok(()) => (),
                     Err(ldap_err) => {
                         // Cannot return the error from drop but at least we can log it.
@@ -100,6 +106,7 @@ where
 }
 
 /// Just a DRY helper for calling `finish()` on the stream.
+#[instrument(level = Level::TRACE, skip_all, ret)]
 async fn finish_stream<'a, S, A>(stream: &mut SearchStream<'a, S, A>) -> Result<(), LdapError>
 where
     S: AsRef<str> + Send + Sync + 'a,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,127 @@
+//! Native rust streams for streaming searches
+//!
+
+use futures::{Stream, executor::block_on};
+use ldap3::{LdapError, LdapResult, SearchEntry, SearchStream, StreamState};
+use tracing::{Level, error, info, instrument};
+
+use crate::{Error, Record};
+
+/// This wrapper exists solely for the purpose of running some cleanup in `drop()`.
+///
+/// This should be refactored to implement `AsyncDrop` when it gets stabilized:
+/// https://github.com/rust-lang/rust/issues/126482
+struct StreamDropWrapper<'a, S, A>
+where
+    S: AsRef<str> + Send + Sync + 'a,
+    A: AsRef<[S]> + Send + Sync + 'a,
+{
+    pub search_stream: SearchStream<'a, S, A>,
+}
+
+impl<'a, S, A> Drop for StreamDropWrapper<'a, S, A>
+where
+    S: AsRef<str> + Send + Sync + 'a,
+    A: AsRef<[S]> + Send + Sync + 'a,
+{
+    fn drop(&mut self) {
+        // Making this blocking call in drop is suboptimal.
+        // We should use async-drop, when it's stabilized:
+        // https://github.com/rust-lang/rust/issues/126482
+        block_on(self.cleanup());
+    }
+}
+
+impl<'a, S, A> StreamDropWrapper<'a, S, A>
+where
+    S: AsRef<str> + Send + Sync + 'a,
+    A: AsRef<[S]> + Send + Sync + 'a,
+{
+    ///
+    /// Cleanup the stream. This method should be called when dropping the stream.
+    ///
+    /// This method will cleanup the stream and close the connection.
+    ///
+    ///
+    /// # Errors
+    ///
+    /// No errors are returned, as this is meant to be called from `drop()`.
+    /// Traces are emitted though.
+    ///
+    #[instrument(level = Level::TRACE, skip_all)]
+    async fn cleanup(&mut self) -> () {
+        // Calling this might not be strictly necessary,
+        // but it's probably expected so let's just do it.
+        // I don't think this does any networking most of the time.
+        let finish_result = self.search_stream.finish().await;
+
+        match finish_result.success() {
+            Ok(_) => (), // All good.
+            // This is returned if the stream is cancelled in the middle.
+            // Which is fine for us.
+            // https://ldap.com/ldap-result-code-reference-client-side-result-codes/#rc-userCanceled
+            Err(LdapError::LdapResult {
+                result: LdapResult { rc: 88, .. },
+            }) => (),
+            Err(finish_err) => error!("The stream finished with an error: {finish_err}"),
+        }
+
+        match self.search_stream.state() {
+            // Stream processed to the end, no need to cancel the operation.
+            // This should be the common case.
+            StreamState::Done | StreamState::Closed => (),
+            StreamState::Error => {
+                error!(
+                    "Stream is in Error state. Not trying to cancel it as it could do more harm than good."
+                );
+            }
+            StreamState::Fresh | StreamState::Active => {
+                info!("Stream is still open. Issuing cancellation to the server.");
+                let msgid = self.search_stream.ldap_handle().last_id();
+                let result = self.search_stream.ldap_handle().abandon(msgid).await;
+
+                match result {
+                    Ok(_) => (),
+                    Err(err) => {
+                        error!("Error abandoning search result: {:?}", err);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A helper to create native rust streams out of `ldap3::SearchStream`s.
+pub(crate) fn to_native_stream<'a, S, A>(
+    ldap3_stream: SearchStream<'a, S, A>,
+) -> Result<impl Stream<Item = Result<Record, Error>> + 'a + use<'a, S, A>, Error>
+where
+    S: AsRef<str> + Send + Sync + 'a,
+    A: AsRef<[S]> + Send + Sync + 'a,
+{
+    // This will handle stream cleanup.
+    let stream_wrapper = StreamDropWrapper {
+        search_stream: ldap3_stream,
+    };
+
+    // Produce the steam itself by unfolding.
+    let stream = futures::stream::try_unfold(stream_wrapper, async |mut search| {
+        match search.search_stream.next().await {
+            // In the middle of the stream. Produce the next result.
+            Ok(Some(result_entry)) => Ok(Some((
+                Record {
+                    search_entry: SearchEntry::construct(result_entry),
+                },
+                search,
+            ))),
+            // Stream is done.
+            Ok(None) => Ok(None),
+            Err(ldap_error) => Err(Error::Query(
+                format!("Error getting next record: {ldap_error:?}"),
+                ldap_error,
+            )),
+        }
+    });
+
+    Ok(stream)
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -25,7 +25,6 @@ where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,
 {
-
     /// Anyway nowadays we do most cleanup in the stream end, so this does nothing.
     /// The risk still exists if the stream is dropped mid way though.
     ///
@@ -46,9 +45,7 @@ where
                 // This does necessitate that we're in a multithread executor though.
                 warn!("Dropping a stream mid way. Performing blocking cleanup in drop().");
                 let result = block_in_place(|| {
-                    Handle::current().block_on(async move {
-                        self.cleanup().await
-                    })
+                    Handle::current().block_on(async move { self.cleanup().await })
                 });
                 match result {
                     Ok(()) => (),
@@ -174,11 +171,12 @@ where
                 // return the potential error.
                 match cleanup_result {
                     Ok(()) => Ok(None),
-                    Err(ldap_err) => {
-                        Err(Error::Query(String::from("Error finishing the streaming search"), ldap_err))
-                    }
+                    Err(ldap_err) => Err(Error::Query(
+                        String::from("Error finishing the streaming search"),
+                        ldap_err,
+                    )),
                 }
-            },
+            }
             Err(ldap_error) => Err(Error::Query(
                 format!("Error getting next record: {ldap_error:?}"),
                 ldap_error,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,7 +4,7 @@
 use futures::Stream;
 use ldap3::{LdapError, LdapResult, SearchEntry, SearchStream, StreamState};
 use tokio::{runtime::Handle, task::block_in_place};
-use tracing::{Level, error, info, instrument};
+use tracing::{Level, error, info, instrument, warn};
 
 use crate::{Error, Record};
 
@@ -42,6 +42,7 @@ where
                 // and so the lifetime `'a` also guarantees that we are now in a tokio managed thread.
                 // Thus we can run some async code with block_in_place().
                 // This does necessitate that we're in a multithread executor though.
+                warn!("Dropping a stream mid way. Performing blocking cleanup in drop().");
                 let result = block_in_place(|| {
                     Handle::current().block_on(async move {
                         self.cleanup().await

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -24,11 +24,32 @@ where
     S: AsRef<str> + Send + Sync + 'a,
     A: AsRef<[S]> + Send + Sync + 'a,
 {
+    /// ⚠️ Deadlock risk
+    ///
+    /// Sporadic async deadlocks have been encountered here.
+    /// Some version of [Futurelock](https://rfd.shared.oxide.computer/rfd/0609),
+    /// I believe it's due to ldap3 storing stream adaptors inside tokio mutexes
+    /// in combination with some future structures.
+    ///
+    /// Anyway nowadays we do most cleanup in the stream end, so this does nothing.
+    /// The risk still exists if the stream is dropped mid way though.
     fn drop(&mut self) {
-        // Making this blocking call in drop is suboptimal.
-        // We should use async-drop, when it's stabilized:
-        // https://github.com/rust-lang/rust/issues/126482
-        block_on(self.cleanup());
+        match self.search_stream.state() {
+            // Avoiding the block if this stream has already been cleaned up.
+            StreamState::Closed | StreamState::Error => (),
+            StreamState::Fresh | StreamState::Active | StreamState::Done => {
+                // Making this blocking call in drop is suboptimal.
+                // We should use async-drop, when it's stabilized:
+                // https://github.com/rust-lang/rust/issues/126482
+                match block_on(self.cleanup()) {
+                    Ok(()) => (),
+                    Err(ldap_err) => {
+                        // Cannot return the error from drop but at least we can log it.
+                        error!("Error in finishing the stream: {ldap_err}")
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -43,51 +64,61 @@ where
     /// This method will cleanup the stream and close the connection.
     ///
     ///
-    /// # Errors
+    /// # Error state
     ///
-    /// No errors are returned, as this is meant to be called from `drop()`.
-    /// Traces are emitted though.
-    ///
+    /// If the stream is already in an error state this won't do anything.
+    /// An Ok result is returned.
     #[instrument(level = Level::TRACE, skip_all)]
-    async fn cleanup(&mut self) -> () {
-        // Calling this might not be strictly necessary,
-        // but it's probably expected so let's just do it.
-        // I don't think this does any networking most of the time.
-        let finish_result = self.search_stream.finish().await;
-
-        match finish_result.success() {
-            Ok(_) => (), // All good.
-            // This is returned if the stream is cancelled in the middle.
-            // Which is fine for us.
-            // https://ldap.com/ldap-result-code-reference-client-side-result-codes/#rc-userCanceled
-            Err(LdapError::LdapResult {
-                result: LdapResult { rc: 88, .. },
-            }) => (),
-            Err(finish_err) => error!("The stream finished with an error: {finish_err}"),
-        }
-
+    async fn cleanup(&mut self) -> Result<(), LdapError> {
         match self.search_stream.state() {
-            // Stream processed to the end, no need to cancel the operation.
-            // This should be the common case.
-            StreamState::Done | StreamState::Closed => (),
+            // `cleanup()` already called when running it to the end.
+            // Nothing to here anymore
+            StreamState::Closed => Ok(()),
+            // Stream ended but not yet closed.
+            // Doing it here.
+            StreamState::Done => finish_stream(&mut self.search_stream).await,
             StreamState::Error => {
                 error!(
                     "Stream is in Error state. Not trying to cancel it as it could do more harm than good."
                 );
+                // We don't have an LdapError to return here.
+                Ok(())
             }
             StreamState::Fresh | StreamState::Active => {
                 info!("Stream is still open. Issuing cancellation to the server.");
-                let msgid = self.search_stream.ldap_handle().last_id();
-                let result = self.search_stream.ldap_handle().abandon(msgid).await;
 
-                match result {
-                    Ok(_) => (),
-                    Err(err) => {
-                        error!("Error abandoning search result: {:?}", err);
-                    }
-                }
+                // Let's first call finish according to the docs.
+                // This probably wont do too much but it gives the adapters a chance for some cleanup.
+                finish_stream(&mut self.search_stream).await?;
+
+                // Then the actual cancellation.
+                let msgid = self.search_stream.ldap_handle().last_id();
+                self.search_stream.ldap_handle().abandon(msgid).await
             }
         }
+    }
+}
+
+/// Just a DRY helper for calling `finish()` on the stream.
+async fn finish_stream<'a, S, A>(stream: &mut SearchStream<'a, S, A>) -> Result<(), LdapError>
+where
+    S: AsRef<str> + Send + Sync + 'a,
+    A: AsRef<[S]> + Send + Sync + 'a,
+{
+    // Calling this might not be strictly necessary,
+    // but it's probably expected so let's just do it.
+    // I don't think this does any networking most of the time.
+    let finish_result = stream.finish().await;
+
+    match finish_result.success() {
+        Ok(_) => Ok(()), // All good.
+        // This is returned if the stream is cancelled in the middle.
+        // Which is fine for us.
+        // https://ldap.com/ldap-result-code-reference-client-side-result-codes/#rc-userCanceled
+        Err(LdapError::LdapResult {
+            result: LdapResult { rc: 88, .. },
+        }) => Ok(()),
+        Err(finish_err) => Err(finish_err),
     }
 }
 
@@ -115,7 +146,23 @@ where
                 search,
             ))),
             // Stream is done.
-            Ok(None) => Ok(None),
+            Ok(None) => {
+                // Performing the cleanup here before yielding the end of the stream.
+                // This is nice place for this as we're already in an async context.
+                // The alternative is to block on this in `drop()`.
+                // That still has to be called because streams may be dropped mid way too,
+                // but running them to completion is assumed to be the common case.
+                let cleanup_result = search.cleanup().await;
+
+                // Doing the cleanup here (as opposed to drop) also has the advantage that we can
+                // return the potential error.
+                match cleanup_result {
+                    Ok(()) => Ok(None),
+                    Err(ldap_err) => {
+                        Err(Error::Query(String::from("Error finishing the streaming search"), ldap_err))
+                    }
+                }
+            },
             Err(ldap_error) => Err(Error::Query(
                 format!("Error getting next record: {ldap_error:?}"),
                 ldap_error,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,7 +4,7 @@
 use futures::Stream;
 use ldap3::{LdapError, LdapResult, SearchEntry, SearchStream, StreamState};
 use tokio::{runtime::Handle, task::block_in_place};
-use tracing::{Level, error, info, instrument, warn};
+use tracing::{Level, debug, error, instrument, warn};
 
 use crate::{Error, Record};
 
@@ -28,6 +28,8 @@ where
 
     /// Anyway nowadays we do most cleanup in the stream end, so this does nothing.
     /// The risk still exists if the stream is dropped mid way though.
+    ///
+    /// In this case there might exist a possibility of a futurelock too.
     fn drop(&mut self) {
         match self.search_stream.state() {
             // Avoiding the block if this stream has already been cleaned up.
@@ -92,7 +94,7 @@ where
                 Ok(())
             }
             StreamState::Fresh | StreamState::Active => {
-                info!("Stream is still open. Issuing cancellation to the server.");
+                debug!("Stream is still open. Issuing cancellation to the server.");
 
                 // Let's first call finish according to the docs.
                 // This probably wont do too much but it gives the adapters a chance for some cleanup.
@@ -160,7 +162,13 @@ where
                 // The alternative is to block on this in `drop()`.
                 // That still has to be called because streams may be dropped mid way too,
                 // but running them to completion is assumed to be the common case.
-                let cleanup_result = search.cleanup().await;
+                //
+                // Actually we cannot call `self.cleanup()` here because that will send
+                // unnecessary search abandon if the stream had no adaptors:
+                // https://github.com/inejge/ldap3/issues/155
+                //
+                // Just finishing is okay though.
+                let cleanup_result = finish_stream(&mut search.search_stream).await;
 
                 // Doing the cleanup here (as opposed to drop) also has the advantage that we can
                 // return the potential error.

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -820,7 +820,7 @@ fn random_uid() -> String {
         .to_owned()
 }
 
-/// Get ldap configuration for conneting to the test server.
+/// Get ldap configuration for connecting to the test server.
 pub fn ldap_config() -> anyhow::Result<LdapConfig> {
     let config = LdapConfig {
         bind_dn: String::from("cn=manager"),

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -484,7 +484,7 @@ pub async fn test_search_stream_drop<Client: DerefMut<Target = LdapClient>>(
     mut client: Client,
 ) -> anyhow::Result<()> {
     // Here we always want to trace.
-    // enable_tracing_subscriber();
+    enable_tracing_subscriber();
 
     let name_filter = ContainsFilter::from("cn".to_string(), "J".to_string());
     let attributes = vec!["cn", "sn", "uid"];

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -43,7 +43,13 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use rand::RngExt;
 use serde::Deserialize;
-use std::{collections::HashSet, num::{NonZero, NonZeroU16}, ops::DerefMut, str::FromStr, sync::Once};
+use std::{
+    collections::HashSet,
+    num::{NonZero, NonZeroU16},
+    ops::DerefMut,
+    str::FromStr,
+    sync::Once,
+};
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
 use url::Url;
@@ -86,7 +92,10 @@ pub struct User {
 
 #[derive(Deserialize)]
 pub struct MultiValueUser {
-    #[expect(dead_code, reason = "Having this here will still test the deserialization.")]
+    #[expect(
+        dead_code,
+        reason = "Having this here will still test the deserialization."
+    )]
     pub dn: SimpleDN,
     #[serde(rename = "objectClass")]
     pub object_class: Vec<String>,
@@ -299,7 +308,7 @@ pub async fn streaming_search<Client: DerefMut<Target = LdapClient>>(
             &name_filter,
             &attra,
             None,
-            Vec::new()
+            Vec::new(),
         )
         .await?;
 
@@ -525,7 +534,7 @@ pub async fn test_streaming_search_no_records<Client: DerefMut<Target = LdapClie
             &name_filter,
             &attributes,
             None,
-            Vec::new()
+            Vec::new(),
         )
         .await?;
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -17,139 +17,139 @@ async fn get_test_client() -> anyhow::Result<LdapClient> {
     Ok(client)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_create_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_no_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_no_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_multiple_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_multiple_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_multi_valued() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_multi_valued(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_update_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_no_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_update_no_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_uid_record() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_update_uid_record(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn streaming_search() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::streaming_search(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn streaming_search_paged() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::streaming_search_paged(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn sorted_paged_search() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::sorted_paged_search(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn sorted_paged_search_reverse() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::sorted_paged_search_reverse(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_stream_drop() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_search_stream_drop(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_streaming_search_no_records() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_streaming_search_no_records(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_delete() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_delete(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_no_record_delete() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_no_record_delete(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_group() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_create_group(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_add_users_to_group() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_add_users_to_group(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_members() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_get_members(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_remove_users_from_group() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_remove_users_from_group(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_associated_groups() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_associated_groups(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_authenticate_success() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_authenticate_success(Box::new(client)).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_authenticate_wrong_password() -> anyhow::Result<()> {
     let client = get_test_client().await?;
     client_test_cases::test_authenticate_wrong_password(Box::new(client)).await

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -21,7 +21,7 @@ async fn build_pool() -> anyhow::Result<Pool> {
     Ok(pool)
 }
 
-/// A convenience function for runnig the test function in parallel with a pool.
+/// A convenience function for running the test function in parallel with a pool.
 /// This should be used to evoke the test functions in `client_test_cases`.
 ///
 /// Tries to simulate real pool usage.
@@ -42,117 +42,117 @@ where
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_create_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_no_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_no_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_multiple_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_multiple_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_multi_valued() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_multi_valued).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_update_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_no_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_update_no_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_uid_record() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_update_uid_record).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn streaming_search() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::streaming_search).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn streaming_search_paged() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::streaming_search_paged).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn sorted_paged_search() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::sorted_paged_search).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn sorted_paged_search_reverse() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::sorted_paged_search_reverse).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_search_stream_drop() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_search_stream_drop).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_streaming_search_no_records() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_streaming_search_no_records).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_delete() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_delete).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_no_record_delete() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_no_record_delete).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_group() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_create_group).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_add_users_to_group() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_add_users_to_group).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_members() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_get_members).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_remove_users_from_group() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_remove_users_from_group).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_associated_groups() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_associated_groups).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_authenticate_success() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_authenticate_success).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_authenticate_wrong_password() -> anyhow::Result<()> {
     dispatch_parallel_test(client_test_cases::test_authenticate_wrong_password).await
 }


### PR DESCRIPTION
I started witnessing sporadic deadlocks in stream cleanup. Some variant of [Futurelock](https://rfd.shared.oxide.computer/rfd/0609). This PR improves the stream cleanup significantly, but doesn't entirely rule out a deadlock when dropping a stream midway.


# What's changed

Now for streams that run to completion the cleanup will be run in the stream itself before yielding the final `Ok(None)`. Cleanup is only ever run in the destructor if the stream is dropped before finishing. This sidesteps the problems in the common case, and allows us to return cleanup errors too. (This is the reason for a major version bump too, as it's a pretty big behavioral change.)

Additionally the sync/async glue in the stream destructor was updated to use tokio in the hopes that using the same runtime might reduce deadlock chances. `ldap3` already explicitly depends on tokio so this isn't really a new dependency, although it does mean that we have to use multithreaded version. That too is the common case so it should be okay.

While working on this I refactored the stream stuff into it's own module just for clarity.