### PR TITLE
feat: make group object class configurable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1385,18 +1385,19 @@ impl LdapClient {
     ///
     ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
     ///
-    ///     let result = client.get_associtated_groups("ou=groups,dc=example,dc=com",
+    ///     let result = client.get_associated_groups("ou=groups,dc=example,dc=com",
     ///     "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com").await;
     /// }
     /// ```
-    pub async fn get_associtated_groups(
+    pub async fn get_associated_groups(
         &mut self,
         group_ou: &str,
         user_dn: &str,
+        grp_obj_cls: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let group_filter = Box::new(EqFilter::from(
             "objectClass".to_string(),
-            "groupOfNames".to_string(),
+            grp_obj_cls.unwrap_or("groupOfNames").into(),
         ));
 
         let user_filter = Box::new(EqFilter::from("member".to_string(), user_dn.to_string()));
@@ -1483,7 +1484,7 @@ struct SerializeWrapper(#[serde(with = "Ldap3SearchEntry")] ldap3::SearchEntry);
 
 // Allowing users to debug serialization issues from the logs.
 #[instrument(level = Level::DEBUG)]
-fn to_signle_value<T: for<'a> Deserialize<'a>>(search_entry: SearchEntry) -> Result<T, Error> {
+fn to_single_value<T: for<'a> Deserialize<'a>>(search_entry: SearchEntry) -> Result<T, Error> {
     let string_attributes = search_entry
         .attrs
         .into_iter()
@@ -1765,7 +1766,7 @@ mod tests {
             bin_attrs: HashMap::new(),
         };
 
-        let test = to_signle_value::<TestSingleValued>(entry);
+        let test = to_single_value::<TestSingleValued>(entry);
 
         let test = test.unwrap();
         assert_eq!(test.key1, "value1".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1361,6 +1361,7 @@ impl LdapClient {
     ///
     /// * `group_ou` - The ou to search for the groups
     /// * `user_dn` - The dn of the user
+    /// * `grp_obj_class` - An optional `objectClass` in case
     ///
     /// # Returns
     ///
@@ -1386,7 +1387,8 @@ impl LdapClient {
     ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
     ///
     ///     let result = client.get_associated_groups("ou=groups,dc=example,dc=com",
-    ///     "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com").await;
+    ///         "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com",
+    ///         None).await;
     /// }
     /// ```
     pub async fn get_associated_groups(
@@ -1451,6 +1453,50 @@ impl LdapClient {
             .collect::<Vec<String>>();
 
         Ok(record)
+    }
+
+    ///
+    /// Get the groups associated with a user in the LDAP server. The user will be searched in the provided base DN.
+    ///
+    /// # Arguments
+    ///
+    /// * `group_ou` - The ou to search for the groups
+    /// * `user_dn` - The dn of the user
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Vec<String>, Error>` - Returns a vector of group names
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use simple_ldap::{LdapClient, LdapConfig};
+    /// use url::Url;
+    ///
+    /// #[tokio::main]
+    /// async fn main(){
+    ///     let ldap_config = LdapConfig {
+    ///         bind_dn: String::from("cn=manager"),
+    ///         bind_password: String::from("password"),
+    ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
+    ///         dn_attribute: None,
+    ///         connection_settings: None
+    ///     };
+    ///
+    ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
+    ///
+    ///     let result = client.get_associated_groups("ou=groups,dc=example,dc=com",
+    ///     "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com").await;
+    /// }
+    /// ```
+    #[deprecated = "foo"]
+    pub async fn get_associtated_groups(
+        &mut self,
+        group_ou: &str,
+        user_dn: &str,
+    ) -> Result<Vec<String>, Error> {
+        self.get_associated_groups(group_ou, user_dn, None).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub extern crate ldap3;
 const LDAP_ENTRY_DN: &str = "entryDN";
 const NO_SUCH_RECORD: u32 = 32;
 
-/// Possible choices for the objectClass attribute of group entries.
+/// Possible choices for the `objectClass` attribute of group entries.
 #[derive(Debug, Copy, Clone)]
 pub enum GroupObjectClass {
     Group,
@@ -1385,11 +1385,11 @@ impl LdapClient {
     ///
     /// * `group_ou` - The ou to search for the groups
     /// * `user_dn` - The dn of the user
-    /// * `grp_obj_class` - An optional [`GroupObjectClass`]
+    /// * `grp_obj_cls` - The object class of groups to use during the search. When `None` is provided it will default to "groupOfNames"
     ///
     /// # Returns
     ///
-    /// * `Result<Vec<String>, Error>` - Returns a vector of group names
+    /// * `Result<Vec<String>, Error>` - Returns a vector of group names. Will be empty when there are no associated groups
     ///
     ///
     /// # Example
@@ -1458,9 +1458,7 @@ impl LdapClient {
         let records = result.unwrap().0;
 
         if records.is_empty() {
-            return Err(Error::NotFound(String::from(
-                "User does not belong to any groups",
-            )));
+            return Ok(Vec::new());
         }
 
         let record = records
@@ -1510,11 +1508,14 @@ impl LdapClient {
     ///
     ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
     ///
-    ///     let result = client.get_associated_groups("ou=groups,dc=example,dc=com",
+    ///     let result = client.get_associtated_groups("ou=groups,dc=example,dc=com",
     ///     "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com").await;
     /// }
     /// ```
-    #[deprecated = "foo"]
+    #[deprecated(
+        since = "10.1.0",
+        note = "Please use `get_associated_groups` instead which also allows specifiying a group's object class. This method will be removed in a future release."
+    )]
     pub async fn get_associtated_groups(
         &mut self,
         group_ou: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,9 @@ const LDAP_ENTRY_DN: &str = "entryDN";
 const NO_SUCH_RECORD: u32 = 32;
 
 /// Possible choices for the `objectClass` attribute of group entries.
+///
+/// `GroupOfNames` is currently regarded as the default variant and is thus the one being returned
+/// by the impl of `Default`.
 #[derive(Debug, Copy, Clone)]
 pub enum GroupObjectClass {
     Group,
@@ -184,12 +187,12 @@ pub enum GroupObjectClass {
     GroupOfUniqueNames,
 }
 
-impl GroupObjectClass {
-    fn as_str(&self) -> &'static str {
+impl fmt::Display for GroupObjectClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Self::Group => "group",
-            Self::GroupOfNames => "groupOfNames",
-            Self::GroupOfUniqueNames => "groupOfUniqueNames",
+            Self::Group => write!(f, "group"),
+            Self::GroupOfNames => write!(f, "groupOfNames"),
+            Self::GroupOfUniqueNames => write!(f, "groupOfUniqueNames"),
         }
     }
 }
@@ -1385,7 +1388,7 @@ impl LdapClient {
     ///
     /// * `group_ou` - The ou to search for the groups
     /// * `user_dn` - The dn of the user
-    /// * `grp_obj_cls` - The object class of groups to use during the search. When `None` is provided it will default to "groupOfNames"
+    /// * `grp_obj_cls` - The object class of groups to use during the search
     ///
     /// # Returns
     ///
@@ -1412,18 +1415,18 @@ impl LdapClient {
     ///
     ///     let result = client.get_associated_groups("ou=groups,dc=example,dc=com",
     ///         "uid=bd9b91ec-7a69-4166-bf67-cc7e553b2fd9,ou=people,dc=example,dc=com",
-    ///         None).await;
+    ///         GroupObjectClass::default()).await;
     /// }
     /// ```
     pub async fn get_associated_groups(
         &mut self,
         group_ou: &str,
         user_dn: &str,
-        grp_obj_cls: Option<GroupObjectClass>,
+        grp_obj_cls: GroupObjectClass,
     ) -> Result<Vec<String>, Error> {
         let group_filter = Box::new(EqFilter::from(
             "objectClass".to_string(),
-            grp_obj_cls.unwrap_or_default().as_str().into(),
+            grp_obj_cls.to_string(),
         ));
 
         let user_filter = Box::new(EqFilter::from("member".to_string(), user_dn.to_string()));
@@ -1521,7 +1524,10 @@ impl LdapClient {
         group_ou: &str,
         user_dn: &str,
     ) -> Result<Vec<String>, Error> {
-        match self.get_associated_groups(group_ou, user_dn, None).await {
+        match self
+            .get_associated_groups(group_ou, user_dn, GroupObjectClass::default())
+            .await
+        {
             Ok(v) if v.is_empty() => Err(Error::NotFound(String::from(
                 "User does not belong to any groups",
             ))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,7 +1521,12 @@ impl LdapClient {
         group_ou: &str,
         user_dn: &str,
     ) -> Result<Vec<String>, Error> {
-        self.get_associated_groups(group_ou, user_dn, None).await
+        match self.get_associated_groups(group_ou, user_dn, None).await {
+            Ok(v) if v.is_empty() => Err(Error::NotFound(String::from(
+                "User does not belong to any groups",
+            ))),
+            r => r,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,30 @@ pub extern crate ldap3;
 const LDAP_ENTRY_DN: &str = "entryDN";
 const NO_SUCH_RECORD: u32 = 32;
 
+/// Possible choices for the objectClass attribute of group entries.
+#[derive(Debug, Copy, Clone)]
+pub enum GroupObjectClass {
+    Group,
+    GroupOfNames,
+    GroupOfUniqueNames,
+}
+
+impl GroupObjectClass {
+    fn as_str(&self) -> &'static str {
+        match *self {
+            Self::Group => "group",
+            Self::GroupOfNames => "groupOfNames",
+            Self::GroupOfUniqueNames => "groupOfUniqueNames",
+        }
+    }
+}
+
+impl Default for GroupObjectClass {
+    fn default() -> Self {
+        Self::GroupOfNames
+    }
+}
+
 /// Configuration and authentication for LDAP connection
 #[derive(derive_more::Debug, Clone)]
 pub struct LdapConfig {
@@ -1361,7 +1385,7 @@ impl LdapClient {
     ///
     /// * `group_ou` - The ou to search for the groups
     /// * `user_dn` - The dn of the user
-    /// * `grp_obj_class` - An optional `objectClass` in case
+    /// * `grp_obj_class` - An optional [`GroupObjectClass`]
     ///
     /// # Returns
     ///
@@ -1395,11 +1419,11 @@ impl LdapClient {
         &mut self,
         group_ou: &str,
         user_dn: &str,
-        grp_obj_cls: Option<&str>,
+        grp_obj_cls: Option<GroupObjectClass>,
     ) -> Result<Vec<String>, Error> {
         let group_filter = Box::new(EqFilter::from(
             "objectClass".to_string(),
-            grp_obj_cls.unwrap_or("groupOfNames").into(),
+            grp_obj_cls.unwrap_or_default().as_str().into(),
         ));
 
         let user_filter = Box::new(EqFilter::from("member".to_string(), user_dn.to_string()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1388,7 +1388,7 @@ impl LdapClient {
     ///
     /// * `group_ou` - The ou to search for the groups
     /// * `user_dn` - The dn of the user
-    /// * `grp_obj_cls` - The object class of groups to use during the search
+    /// * `group_object_class` - The object class of groups to use during the search
     ///
     /// # Returns
     ///
@@ -1398,7 +1398,7 @@ impl LdapClient {
     /// # Example
     ///
     /// ```no_run
-    /// use simple_ldap::{LdapClient, LdapConfig};
+    /// use simple_ldap::{GroupObjectClass, LdapClient, LdapConfig};
     /// use url::Url;
     ///
     /// #[tokio::main]
@@ -1422,11 +1422,11 @@ impl LdapClient {
         &mut self,
         group_ou: &str,
         user_dn: &str,
-        grp_obj_cls: GroupObjectClass,
+        group_object_class: GroupObjectClass,
     ) -> Result<Vec<String>, Error> {
         let group_filter = Box::new(EqFilter::from(
             "objectClass".to_string(),
-            grp_obj_cls.to_string(),
+            group_object_class.to_string(),
         ));
 
         let user_filter = Box::new(EqFilter::from("member".to_string(), user_dn.to_string()));

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -728,9 +728,10 @@ pub async fn test_associated_groups<Client: DerefMut<Target = LdapClient>>(
     mut client: Client,
 ) -> anyhow::Result<()> {
     let result = client
-        .get_associtated_groups(
+        .get_associated_groups(
             "ou=group,dc=example,dc=com",
             "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com",
+            None
         )
         .await?;
 

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -56,7 +56,7 @@ use url::Url;
 use uuid::Uuid;
 
 use simple_ldap::{
-    Error, LdapClient, LdapConfig, SimpleDN, SortBy,
+    Error, GroupObjectClass, LdapClient, LdapConfig, SimpleDN, SortBy,
     filter::{ContainsFilter, EqFilter},
     ldap3::{Mod, Scope},
 };
@@ -731,7 +731,7 @@ pub async fn test_associated_groups<Client: DerefMut<Target = LdapClient>>(
         .get_associated_groups(
             "ou=group,dc=example,dc=com",
             "uid=e219fbc0-6df5-4bc3-a6ee-986843bb157e,ou=people,dc=example,dc=com",
-            None
+            GroupObjectClass::default(),
         )
         .await?;
 


### PR DESCRIPTION
This PR
* adds a new `get_associated_groups` method to `LdapClient` to correct a previous typo
* adds a new enum `GroupObjectClass`
* adds a new argument to `get_associated_groups` to let users specify a group's object class
* returns an empty `Vec` from `get_associated_groups` when no groups can be found
* deprecates `get_associtated_groups` and makes it a thin wrapper for `get_associated_groups`

closes #57, closes #48