### PR TITLE
Authenticate() soundness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,13 @@ url = "2.5.4"
 simple-ldap = { path = ".", features = ["pool"] }
 anyhow = "1.0.104"
 rand = "0.10.1"
+serde_with = "3.12.0"
+serde_json = "1.0.142"
+serde-aux = "4.7.0"
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = "0.3.23"
 # v4 is random uids.
 uuid = { version = "1.16.0", features = ["v4", "serde"] }
-serde_with = "3.12.0"
-tracing-subscriber = "0.3.23"
-serde_json = "1.0.142"
 
 [features]
 default = ["tls-native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/keaz/simple-ldap"
 keywords = ["ldap", "ldap3", "async", "high-level"]
 name = "simple-ldap"
-version = "10.1.0"
+version = "11.0.0"
 edition = "2024"
 
 
@@ -19,7 +19,7 @@ chumsky = "0.13.0"
 deadpool = { version = "0.13.0", optional = true }
 derive_more = { version = "2.0.1", features = ["debug", "display", "try_from"] }
 futures = "0.3.31"
-itertools = "0.14.0"
+itertools = "0.15.0"
 ldap3 = { version = "0.12.1", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde-value = "0.7.0"
@@ -35,7 +35,7 @@ url = "2.5.4"
 # This little hack is needed for enabling optional features during testing.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 simple-ldap = { path = ".", features = ["pool"] }
-anyhow = "1.0.98"
+anyhow = "1.0.104"
 rand = "0.10.1"
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 # v4 is random uids.
@@ -53,7 +53,7 @@ tls-rustls = ["ldap3/tls-rustls-aws-lc-rs"]
 pool = ["dep:deadpool"]
 
 
-# Lint catlogue: https://rust-lang.github.io/rust-clippy/master/index.html
+# Lint catalogue: https://rust-lang.github.io/rust-clippy/master/index.html
 [lints.clippy]
 all = {level = "warn", priority = -1}
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ async fn main(){
         bind_dn: String::from("cn=manager"),
         bind_password: String::from("password"),
         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-        dn_attribute: None,
         connection_settings: None
     };
     let mut client = LdapClient::new(ldap_config).await.unwrap();

--- a/data/data.ldif
+++ b/data/data.ldif
@@ -69,6 +69,52 @@ cn: David
 ou: people
 uid: 4d9b08fe-9a14-4df0-9831-ea9992837f0d
 
+dn: ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+description: Webcomic characters for testing server side sort
+
+dn: cn=Techno-Mage,ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+cn: Techno-Mage
+sn: Mage
+
+dn: cn=Spirit of the Machine,ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+cn: Spirit of the Machine
+sn: Machine
+
+dn: cn=Fossangel,ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+cn: Fossangel
+sn: Angel
+
+dn: cn=Penguin,ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+cn: Penguin
+sn: Penguin
+
+dn: cn=OpenBlade,ou=analognowhere,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: inetorgperson
+objectClass: organizationalPerson
+objectClass: person
+cn: OpenBlade
+sn: Blade
+
+
 dn: ou=group,dc=example,dc=com
 objectClass: top
 objectClass: organizationalUnit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@
 //!         bind_dn: String::from("cn=manager"),
 //!         bind_password: String::from("password"),
 //!         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-//!         dn_attribute: None,
 //!         connection_settings: None
 //!     };
 //!     let mut client = LdapClient::new(ldap_config).await.unwrap();
@@ -171,9 +170,10 @@ use crate::stream::to_native_stream;
 
 // Would likely be better if we could avoid re-exporting this.
 // I suspect it's only used in some configs?
+// Also in errors actually.
 pub extern crate ldap3;
 
-const LDAP_ENTRY_DN: &str = "entryDN";
+
 const NO_SUCH_RECORD: u32 = 32;
 
 /// Possible choices for the `objectClass` attribute of group entries.
@@ -212,7 +212,6 @@ pub struct LdapConfig {
     pub bind_dn: String,
     #[debug(skip)] // We don't want to print passwords.
     pub bind_password: String,
-    pub dn_attribute: Option<String>,
     /// Low level configuration for the connection.
     /// You can probably skip it.
     #[debug(skip)] // Debug omitted, because it just doesn't implement it.
@@ -223,17 +222,22 @@ pub struct LdapConfig {
 /// High-level LDAP client wrapper on top of ldap3 crate. This wrapper provides a high-level interface to perform LDAP operations
 /// including authentication, search, update, delete
 ///
-#[derive(Debug, Clone)]
+#[derive(derive_more::Debug, Clone)]
 pub struct LdapClient {
     /// The internal connection handle.
     ldap: Ldap,
-    dn_attr: Option<String>,
+
+    // We need to store credentials for rebinding in `self::authenticate()`.
+    bind_dn: String,
+    #[debug(skip)]
+    bind_password: String,
 }
 
 impl LdapClient {
     ///
     /// Creates a new asynchronous LDAP client.s
     /// It's capable of running multiple operations concurrently.
+    ///
     ///
     /// # Bind
     ///
@@ -258,15 +262,12 @@ impl LdapClient {
 
         ldap3::drive!(conn);
 
-        ldap.simple_bind(&config.bind_dn, &config.bind_password)
-            .await
-            .map_err(|ldap_err| Error::Connection(String::from("Bind failed"), ldap_err))?
-            .success()
-            .map_err(|ldap_err| Error::Connection(String::from("Bind failed"), ldap_err))?;
+        bind(&mut ldap, &config.bind_dn, &config.bind_password).await?;
 
-        Ok(Self {
-            dn_attr: config.dn_attribute,
+        Ok(LdapClient {
             ldap,
+            bind_dn: config.bind_dn,
+            bind_password: config.bind_password
         })
     }
 }
@@ -300,20 +301,37 @@ impl LdapClient {
     }
 
     ///
-    /// The user is authenticated by searching for the user in the LDAP server.
-    /// The search is performed using the provided filter. The filter should be a filter that matches a single user.
+    /// Implements a typical "login with LDAP" authentication flow. Intended for server side use.
+    ///
+    /// The user is authenticated by searching for the user in the LDAP server and then trying to bind
+    /// with the provided password and DN found from the `dn_attribute` attribute.
+    ///
+    /// The first few arguments define a search  performed using the provided filter. The filter should be a filter that matches a single user.
+    ///
+    ///
+    /// # Note ⚠️
+    ///
+    /// This will perform binds on the connection. Clones of this client should not be used elsewhere
+    /// concurrently.
+    ///
     ///
     /// # Arguments
     ///
-    /// * `base` - The base DN to search for the user
-    /// * `uid` - The uid of the user
-    /// * `password` - The password of the user
-    /// * `filter` - The filter to search for the user
+    /// ## Search
+    ///
+    /// The first few arguments search for a single user.
+    /// It's okay if the search matches nothing but multiple results will be an error.
+    ///
+    /// - `base` - The base DN for the user search
+    /// - `scope` - Scope for the search
+    /// - `filter` - The filter to search for the user
     ///
     ///
-    /// # Returns
+    /// ## Bind
     ///
-    /// * `Result<(), Error>` - Returns an error if the authentication fails
+    /// - `dn_attribute` - Single valued attribute on the LDAP user object that holds the user DN.
+    ///     - Very like you want to use ["entryDN"](https://datatracker.ietf.org/doc/rfc5020/)
+    /// - `password` - The password of the user we are authenticating
     ///
     ///
     /// # Example
@@ -321,6 +339,8 @@ impl LdapClient {
     /// ```no_run
     /// use simple_ldap::{
     ///     LdapClient, LdapConfig,
+    ///     AuthenticationResult,
+    ///     ldap3::Scope,
     ///     filter::EqFilter
     /// };
     /// use url::Url;
@@ -331,67 +351,91 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
     ///     let mut client = LdapClient::new(ldap_config).await.unwrap();
     ///     let name_filter = EqFilter::from("cn".to_string(), "Sam".to_string());
     ///
-    ///     let result = client.authenticate("", "Sam", "password", Box::new(name_filter)).await;
+    ///     let result = client.authenticate(
+    ///         "ou=people,dc=example,dc=com",
+    ///         Scope::Subtree,
+    ///         &name_filter,
+    ///         "entryDN",
+    ///         "password"
+    ///     ).await;
+    ///
+    ///     match result {
+    ///         Ok(AuthenticationResult::Success) => todo!(),
+    ///         Ok(AuthenticationResult::UserNotFound) => todo!(),
+    ///         Ok(AuthenticationResult::WrongPassword) => todo!(),
+    ///         Err(e) => todo!()
+    ///     }
     /// }
     /// ```
-    pub async fn authenticate(
+    ///
+    /// # See also
+    ///
+    /// LDAP wiki has [a good article](https://ldapwiki.com/wiki/Wiki.jsp?page=LDAP%20Authentication) on LDAP authentication.
+    /// This method essentially implements the most common flow.
+    pub async fn authenticate<F>(
         &mut self,
         base: &str,
-        uid: &str,
+        scope: Scope,
+        filter: &F,
+        dn_attribute: &str,
         password: &str,
-        filter: Box<dyn Filter>,
-    ) -> Result<(), Error> {
-        let attr_dn = self.dn_attr.as_deref().unwrap_or(LDAP_ENTRY_DN);
-
-        let rs = self
-            .ldap
-            .search(base, Scope::OneLevel, filter.filter().as_str(), [attr_dn])
-            .await
-            .map_err(|e| Error::Query("Unable to query user for authentication".into(), e))?;
-
-        let (data, _rs) = rs
-            .success()
-            .map_err(|e| Error::Query("Could not find user for authentication".into(), e))?;
-
-        if data.is_empty() {
-            return Err(Error::NotFound(format!("No record found {uid:?}")));
+    ) -> Result<AuthenticationResult, Error>
+    where
+        F: Filter
+    {
+        match self.search_inner(base, scope, filter, [dn_attribute]).await {
+            // Not finding a user is not an error here.
+            Err(Error::NotFound(..)) => Ok(AuthenticationResult::UserNotFound),
+            // Other errors we pass through.
+            // This includes finding multiple matches.
+            Err(e) => Err(e),
+            // Exactly one user found, continuing authentication.
+            Ok(user_entry) => {
+                // Get the value of the dn_attribute.
+                // (Honestly I'm not sure why we don't just use `dn` directly?)
+                match user_entry.attrs.get(dn_attribute).map(Vec::as_slice) {
+                    // No values
+                    None | Some([]) => {
+                        let message = format!("'DN Attribute' {dn_attribute} wasn't defined on object {dn}",
+                            dn = user_entry.dn
+                        );
+                        Err(Error::AuthenticationFailed(message))
+                    },
+                    // Too many values
+                    Some([_, _, ..]) => {
+                        let message = format!("'DN Attribute' {dn_attribute} is multivalued (on object {dn})",
+                            dn = user_entry.dn
+                        );
+                        Err(Error::AuthenticationFailed(message))
+                    }
+                    // Exactly one value found, as it should.
+                    Some([dn_attribute_value]) => {
+                        // ⚠️ This is a tad unsound. If there are other clones using this ldap handle they too may
+                        // temporarily switch to the user we're authenticating. Ongoing operations may also be cancelled?
+                        // An alternative approach might be to open a new connection for this bind and thus not mess
+                        // with the existing one.
+                        match bind(&mut self.ldap, dn_attribute_value, password).await {
+                            // Authentication was successful. Still need to restore the original user.
+                            Ok(()) => {
+                                bind(&mut self.ldap, &self.bind_dn, &self.bind_password).await
+                                    // Opting to panic here as the connection would be otherwise left with
+                                    // an unexpected user. Some kind of poisoning would be a more complicated option.
+                                    .expect("Failed to restore the connection to it's original user.");
+                                Ok(AuthenticationResult::Success)
+                            },
+                            Err(Error::AuthenticationFailed(_)) => Ok(AuthenticationResult::WrongPassword),
+                            Err(e) => Err(e)
+                        }
+                    }
+                }
+            }
         }
-        if data.len() > 1 {
-            return Err(Error::MultipleResults(format!(
-                "Found multiple records for uid {uid:?}"
-            )));
-        }
-
-        let record = data.first().unwrap().to_owned();
-        let record = SearchEntry::construct(record);
-        let result: HashMap<&str, String> = record
-            .attrs
-            .iter()
-            .filter(|(_, value)| !value.is_empty())
-            .map(|(arrta, value)| (arrta.as_str(), value.first().unwrap().clone()))
-            .collect();
-
-        let entry_dn = result.get(attr_dn).ok_or_else(|| {
-            Error::AuthenticationFailed(format!("Unable to retrieve DN of user {uid}"))
-        })?;
-
-        self.ldap
-            .simple_bind(entry_dn, password)
-            .await
-            .map_err(|_| Error::AuthenticationFailed(format!("Error authenticating user: {uid:?}")))
-            .and_then(|r| {
-                r.success().map_err(|_| {
-                    Error::AuthenticationFailed(format!("Error authenticating user: {uid:?}"))
-                })
-            })
-            .and(Ok(()))
     }
 
     async fn search_inner<'a, F, A, S>(
@@ -488,7 +532,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -566,7 +609,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -653,7 +695,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -783,7 +824,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -853,7 +893,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -970,7 +1009,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1037,7 +1075,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1100,7 +1137,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1187,7 +1223,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1334,7 +1369,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1407,7 +1441,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///
@@ -1534,6 +1567,29 @@ impl LdapClient {
             r => r,
         }
     }
+}
+
+/// Result type for [LdapClient::authenticate()].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthenticationResult {
+    /// User authenticated successfully.
+    Success,
+    /// No user was found.
+    UserNotFound,
+    /// User was found but the authentication failed.
+    WrongPassword,
+}
+
+
+/// Private helper for binding.
+async fn bind(inner_handle: &mut Ldap , bind_dn: &str, bind_password: &str) -> Result<(), Error> {
+    inner_handle.simple_bind(bind_dn, bind_password)
+        .await
+        .map_err(|ldap_err| Error::AuthenticationFailed(format!("Bind failed: {ldap_err}")))?
+        .success()
+        .map_err(|ldap_err| Error::AuthenticationFailed(format!("Bind failed: {ldap_err}")))?;
+
+    Ok(())
 }
 
 /// Empty vec becomes None, otherwise it gets wrapped in Some.
@@ -1764,7 +1820,7 @@ pub enum Error {
     /// Multiple records found for the search criteria
     #[error("{0}")]
     MultipleResults(String),
-    /// Authenticating a user failed.
+    /// Bind failed.
     #[error("{0}")]
     AuthenticationFailed(String),
     /// Error occurred when creating a record

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1538,7 +1538,6 @@ impl LdapClient {
     ///         bind_dn: String::from("cn=manager"),
     ///         bind_password: String::from("password"),
     ///         ldap_url: Url::parse("ldaps://localhost:1389/dc=example,dc=com").unwrap(),
-    ///         dn_attribute: None,
     ///         connection_settings: None
     ///     };
     ///

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -35,7 +35,6 @@ use deadpool::{
 ///         bind_dn: String::from("cn=manager"),
 ///         bind_password: String::from("password"),
 ///         ldap_url: Url::parse("ldap://localhost:1389/dc=example,dc=com").unwrap(),
-///         dn_attribute: None,
 ///         connection_settings: None
 ///     };
 ///     let pool_size = NonZeroUsize::new(10).unwrap();

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -57,7 +57,7 @@ use url::Url;
 use uuid::Uuid;
 
 use simple_ldap::{
-    AuthenticationResult, Error, LdapClient, LdapConfig, SimpleDN, SortBy, filter::{ContainsFilter, EqFilter}, ldap3::{Mod, Scope},
+    AuthenticationResult, Error, GroupObjectClass, LdapClient, LdapConfig, SimpleDN, SortBy, filter::{ContainsFilter, EqFilter}, ldap3::{Mod, Scope},
 };
 
 pub async fn test_create_record<Client: DerefMut<Target = LdapClient>>(

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -43,6 +43,7 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use rand::RngExt;
 use serde::Deserialize;
+use serde_aux::serde_introspection::serde_introspect;
 use std::{
     collections::HashSet,
     num::{NonZero, NonZeroU16},
@@ -340,7 +341,7 @@ pub async fn streaming_search_paged<Client: DerefMut<Target = LdapClient>>(
     // enable_tracing_subscriber();
 
     let name_filter = ContainsFilter::from("cn".to_string(), "J".to_string());
-    let attributes = vec!["cn", "sn", "uid"];
+    let attributes = serde_introspect::<SlimUser>();
     let stream = client
         .streaming_search(
             "ou=people,dc=example,dc=com",
@@ -356,7 +357,7 @@ pub async fn streaming_search_paged<Client: DerefMut<Target = LdapClient>>(
 
     let count = stream
         .and_then(async |record| record.to_record())
-        .try_fold(0, async |sum, _: User| Ok(sum + 1))
+        .try_fold(0, async |sum, _: SlimUser| Ok(sum + 1))
         .await?;
 
     assert_eq!(count, 3);
@@ -364,14 +365,23 @@ pub async fn streaming_search_paged<Client: DerefMut<Target = LdapClient>>(
     Ok(())
 }
 
+/// Simple user representation that can be used to deserialize test users.
+#[derive(Debug, Deserialize)]
+pub struct SlimUser {
+    // pub dn: SimpleDN,
+    pub cn: String,
+    pub sn: String,
+}
+
 pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
     mut client: Client,
 ) -> anyhow::Result<()> {
     // enable_tracing_subscriber();
 
-    // Getting all the users.
+    // Getting all users from a separate OU.
+    let base = "ou=analognowhere,ou=people,dc=example,dc=com";
     let name_filter = EqFilter::from("objectClass".to_string(), "person".to_string());
-    let attributes = vec!["cn", "sn", "uid"];
+    let attributes = serde_introspect::<SlimUser>();
     let cn_sort = vec![SortBy {
         attribute: "cn".to_owned(),
         reverse: false,
@@ -379,7 +389,7 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
 
     let stream = client
         .streaming_search(
-            "ou=people,dc=example,dc=com",
+            base,
             simple_ldap::ldap3::Scope::OneLevel,
             &name_filter,
             &attributes,
@@ -390,7 +400,7 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
         )
         .await?;
 
-    let results: Vec<User> = stream
+    let results: Vec<SlimUser> = stream
         .and_then(async |record| record.to_record())
         .try_collect()
         .await?;
@@ -398,11 +408,11 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
     // Just a bit of debugging.
     println!(
         "Results sorted by CN: {:?}",
-        results.iter().map(|User { cn, .. }| cn).format(", ")
+        results.iter().map(|SlimUser { cn, .. }| cn).format(", ")
     );
 
     assert!(!results.is_empty());
-    assert!(results.is_sorted_by_key(|User { cn, .. }| cn.to_owned()));
+    assert!(results.is_sorted_by_key(|SlimUser { cn, .. }| cn.to_owned()));
 
     // And then another sort attribute just to rule out chance.
 
@@ -413,7 +423,7 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
 
     let stream = client
         .streaming_search(
-            "ou=people,dc=example,dc=com",
+            base,
             simple_ldap::ldap3::Scope::OneLevel,
             &name_filter,
             &attributes,
@@ -424,7 +434,7 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
         )
         .await?;
 
-    let results: Vec<User> = stream
+    let results: Vec<SlimUser> = stream
         .and_then(async |record| record.to_record())
         .try_collect()
         .await?;
@@ -432,11 +442,11 @@ pub async fn sorted_paged_search<Client: DerefMut<Target = LdapClient>>(
     // Just a bit of debugging.
     println!(
         "Results sorted by SN: {:?}",
-        results.iter().map(|User { sn, .. }| sn).format(", ")
+        results.iter().map(|SlimUser { sn, .. }| sn).format(", ")
     );
 
     assert!(!results.is_empty());
-    assert!(results.is_sorted_by_key(|User { sn, .. }| sn.to_owned()));
+    assert!(results.is_sorted_by_key(|SlimUser { sn, .. }| sn.to_owned()));
 
     Ok(())
 }
@@ -446,9 +456,10 @@ pub async fn sorted_paged_search_reverse<Client: DerefMut<Target = LdapClient>>(
 ) -> anyhow::Result<()> {
     // enable_tracing_subscriber();
 
-    // Getting all the users.
+    // Getting all users from a separate OU.
+    let base = "ou=analognowhere,ou=people,dc=example,dc=com";
     let name_filter = EqFilter::from("objectClass".to_string(), "person".to_string());
-    let attributes = vec!["cn", "sn", "uid"];
+    let attributes = serde_introspect::<SlimUser>();
     let sort = vec![SortBy {
         attribute: "cn".to_owned(),
         // This is the key bit in this test.
@@ -457,7 +468,7 @@ pub async fn sorted_paged_search_reverse<Client: DerefMut<Target = LdapClient>>(
 
     let stream = client
         .streaming_search(
-            "ou=people,dc=example,dc=com",
+            base,
             simple_ldap::ldap3::Scope::OneLevel,
             &name_filter,
             &attributes,
@@ -468,7 +479,7 @@ pub async fn sorted_paged_search_reverse<Client: DerefMut<Target = LdapClient>>(
         )
         .await?;
 
-    let results: Vec<User> = stream
+    let results: Vec<SlimUser> = stream
         .and_then(async |record| record.to_record())
         .try_collect()
         .await?;
@@ -476,13 +487,13 @@ pub async fn sorted_paged_search_reverse<Client: DerefMut<Target = LdapClient>>(
     // Just a bit of debugging.
     println!(
         "Results: {:?}",
-        results.iter().map(|User { cn, .. }| cn).format(", ")
+        results.iter().map(|SlimUser { cn, .. }| cn).format(", ")
     );
 
     assert!(!results.is_empty());
 
     let reversed_results = results.into_iter().rev();
-    assert!(reversed_results.is_sorted_by_key(|User { cn, .. }| cn.to_owned()));
+    assert!(reversed_results.is_sorted_by_key(|SlimUser { cn, .. }| cn.to_owned()));
 
     Ok(())
 }
@@ -493,11 +504,13 @@ pub async fn test_search_stream_drop<Client: DerefMut<Target = LdapClient>>(
     // Here we always want to trace.
     enable_tracing_subscriber();
 
+    // Getting all users from a separate OU.
+    let base = "ou=analognowhere,ou=people,dc=example,dc=com";
     let name_filter = ContainsFilter::from("cn".to_string(), "J".to_string());
-    let attributes = vec!["cn", "sn", "uid"];
+    let attributes = serde_introspect::<SlimUser>();
     let stream = client
         .streaming_search(
-            "ou=people,dc=example,dc=com",
+            base,
             simple_ldap::ldap3::Scope::OneLevel,
             &name_filter,
             &attributes,
@@ -523,8 +536,8 @@ pub async fn test_streaming_search_no_records<Client: DerefMut<Target = LdapClie
 ) -> anyhow::Result<()> {
     enable_tracing_subscriber();
 
-    let name_filter = EqFilter::from("cn".to_string(), "JamesX".to_string());
-    let attributes = vec!["cn", "sn", "uid"];
+    let name_filter = EqFilter::from("cn".to_string(), "NonExistent".to_string());
+    let attributes = serde_introspect::<SlimUser>();
     let stream = client
         .streaming_search(
             "ou=people,dc=example,dc=com",
@@ -538,7 +551,7 @@ pub async fn test_streaming_search_no_records<Client: DerefMut<Target = LdapClie
 
     let count = stream
         .and_then(async |record| record.to_record())
-        .try_fold(0, async |sum, _: User| Ok(sum + 1))
+        .try_fold(0, async |sum, _: SlimUser| Ok(sum + 1))
         .await?;
 
     assert_eq!(count, 0);

--- a/tests/client_test_cases/mod.rs
+++ b/tests/client_test_cases/mod.rs
@@ -56,9 +56,7 @@ use url::Url;
 use uuid::Uuid;
 
 use simple_ldap::{
-    Error, GroupObjectClass, LdapClient, LdapConfig, SimpleDN, SortBy,
-    filter::{ContainsFilter, EqFilter},
-    ldap3::{Mod, Scope},
+    AuthenticationResult, Error, LdapClient, LdapConfig, SimpleDN, SortBy, filter::{ContainsFilter, EqFilter}, ldap3::{Mod, Scope},
 };
 
 pub async fn test_create_record<Client: DerefMut<Target = LdapClient>>(
@@ -762,12 +760,12 @@ pub async fn test_authenticate_success<Client: DerefMut<Target = LdapClient>>(
 
     let filter = EqFilter::from("uid".to_string(), uid.clone());
     let auth_result = client
-        .authenticate(base, uid.as_str(), password.as_str(), Box::new(filter))
+        .authenticate(base, Scope::OneLevel, &filter, "entryDN", password.as_str())
         .await;
 
     client.delete(uid.as_str(), base).await?;
 
-    auth_result?;
+    assert_eq!(auth_result?, AuthenticationResult::Success);
 
     Ok(())
 }
@@ -794,16 +792,15 @@ pub async fn test_authenticate_wrong_password<Client: DerefMut<Target = LdapClie
 
     let filter = EqFilter::from("uid".to_string(), uid.clone());
     let auth_result = client
-        .authenticate(base, uid.as_str(), "definitely-wrong", Box::new(filter))
+        .authenticate(base, Scope::OneLevel, &filter, "entryDN", "definitely-wrong")
+
         .await;
 
     client.delete(uid.as_str(), base).await?;
 
-    match auth_result {
-        Err(Error::AuthenticationFailed(_)) => Ok(()),
-        Err(other) => Err(anyhow!("Unexpected error: {other:?}")),
-        Ok(_) => Err(anyhow!("Authentication succeeded unexpectedly")),
-    }
+    assert_eq!(auth_result?, AuthenticationResult::WrongPassword);
+
+    Ok(())
 }
 
 /***************
@@ -836,7 +833,6 @@ pub fn ldap_config() -> anyhow::Result<LdapConfig> {
         bind_dn: String::from("cn=manager"),
         bind_password: String::from("password"),
         ldap_url: Url::parse("ldap://localhost:1389/dc=example,dc=com")?,
-        dn_attribute: None,
         connection_settings: None,
     };
 


### PR DESCRIPTION
Refactoring `authenticate()` to address the issues in #61. This will unblock #58 too.


# Changes

This turned out to be a bigger hurdle than anticipated.

- Authenticate will now rebind after a successful authentication. This was the fundamental cause of unsoundness.
- To accommodate this we need to store the original credentials in the client object.
- Removed the `dn_attr` field from the client as it's only needed in `authenticate()`. Now taken as an argument.
- New search arguments on `authenticate()`
- No longer relying on errors on `authenticate()` responses, a proper enum is returned.
- The error returned from `new()` can now be `AuthenticationFailed`

Additionally I tried tackling #64 by separating the sort test data. This ultimately didn't work but it's still an okay refactor for the tests. Gotta investigate this more.


## Note

I don't use `authenticate()` myself. My interest is mainly preventing this from messing the pooled connections. Feedback on the API is welcome from those that do actually use this.


## Issues

fixes: #61 